### PR TITLE
chore: release v0.7.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.5](https://github.com/redis-developer/redis-enterprise-rs/compare/v0.7.4...v0.7.5) - 2026-01-30
+
+### Added
+
+- add Python bindings ([#2](https://github.com/redis-developer/redis-enterprise-rs/pull/2))
+- initial standalone redis-enterprise crate
+
 ## [0.7.4](https://github.com/redis-developer/redisctl/compare/redis-enterprise-v0.7.3...redis-enterprise-v0.7.4) - 2026-01-23
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1049,7 +1049,7 @@ dependencies = [
 
 [[package]]
 name = "redis-enterprise"
-version = "0.7.4"
+version = "0.7.5"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "redis-enterprise"
-version = "0.7.4"
+version = "0.7.5"
 edition = "2024"
 rust-version = "1.85"
 authors = ["Josh Rotenberg <joshrotenberg@gmail.com>"]


### PR DESCRIPTION



## 🤖 New release

* `redis-enterprise`: 0.7.4 -> 0.7.5 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.7.5](https://github.com/redis-developer/redis-enterprise-rs/compare/v0.7.4...v0.7.5) - 2026-01-30

### Added

- add Python bindings ([#2](https://github.com/redis-developer/redis-enterprise-rs/pull/2))
- initial standalone redis-enterprise crate
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).