### PR TITLE
fix: add README to PyPI package

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,9 @@
 [![Documentation](https://docs.rs/redis-enterprise/badge.svg)](https://docs.rs/redis-enterprise)
 [![CI](https://github.com/redis-developer/redis-enterprise-rs/actions/workflows/ci.yml/badge.svg)](https://github.com/redis-developer/redis-enterprise-rs/actions/workflows/ci.yml)
 [![License](https://img.shields.io/crates/l/redis-enterprise.svg)](https://github.com/redis-developer/redis-enterprise-rs)
+[![PyPI](https://img.shields.io/pypi/v/redis-enterprise.svg)](https://pypi.org/project/redis-enterprise/)
 
-A comprehensive Rust client library for the Redis Enterprise REST API.
+A comprehensive Rust client library for the Redis Enterprise REST API, with Python bindings.
 
 ## Features
 
@@ -96,6 +97,71 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 ```
 
 This enables composition with Tower middleware like circuit breakers, retry, rate limiting, and more.
+
+## Python Bindings
+
+This library also provides Python bindings via PyO3:
+
+```bash
+pip install redis-enterprise
+```
+
+```python
+from redis_enterprise import EnterpriseClient
+
+# Create client
+client = EnterpriseClient(
+    base_url="https://cluster:9443",
+    username="admin@redis.local",
+    password="secret",
+    insecure=True  # For self-signed certs
+)
+
+# Or from environment variables
+client = EnterpriseClient.from_env()
+
+# Async usage
+async def main():
+    dbs = await client.databases()
+    for db in dbs:
+        print(db["name"], db["uid"])
+
+# Sync usage
+dbs = client.databases_sync()
+```
+
+### Python API
+
+- `EnterpriseClient(base_url, username, password, insecure=False, timeout_secs=None)`
+- `EnterpriseClient.from_env()` - Create from environment variables
+
+#### Cluster
+- `cluster_info()` / `cluster_info_sync()` - Get cluster info
+- `cluster_stats()` / `cluster_stats_sync()` - Get cluster statistics
+- `license()` / `license_sync()` - Get license info
+
+#### Databases
+- `databases()` / `databases_sync()` - List all databases
+- `database(uid)` / `database_sync(uid)` - Get database by UID
+
+#### Nodes
+- `nodes()` / `nodes_sync()` - List all nodes
+- `node(uid)` / `node_sync(uid)` - Get node by UID
+
+#### Users
+- `users()` / `users_sync()` - List all users
+
+#### Raw API
+- `get(path)` / `get_sync(path)` - Raw GET request
+- `post(path, body)` / `post_sync(path, body)` - Raw POST request
+- `delete(path)` / `delete_sync(path)` - Raw DELETE request
+
+### Environment Variables
+
+- `REDIS_ENTERPRISE_URL` - Base URL (default: https://localhost:9443)
+- `REDIS_ENTERPRISE_USER` - Username
+- `REDIS_ENTERPRISE_PASSWORD` - Password
+- `REDIS_ENTERPRISE_INSECURE` - Set to "true" for self-signed certs
 
 ## API Coverage
 

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -6,6 +6,7 @@ build-backend = "maturin"
 name = "redis-enterprise"
 version = "0.1.0"
 description = "Python bindings for Redis Enterprise REST API client"
+readme = { file = "../README.md", content-type = "text/markdown" }
 license = { text = "MIT OR Apache-2.0" }
 authors = [
     { name = "Josh Rotenberg", email = "joshrotenberg@gmail.com" }


### PR DESCRIPTION
## Summary
- Point pyproject.toml readme to root README.md
- Add Python bindings documentation to README
- Add PyPI badge

This will show the README on PyPI and document the Python API.