### PR TITLE
chore: release v0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.0](https://github.com/redis-developer/redis-enterprise-rs/compare/v0.7.5...v0.8.0) - 2026-01-30
+
+### Added
+
+- add more specific error variants ([#12](https://github.com/redis-developer/redis-enterprise-rs/pull/12))
+- add fluent API and align with redis-cloud patterns ([#10](https://github.com/redis-developer/redis-enterprise-rs/pull/10))
+
+### Fixed
+
+- add README to PyPI package ([#3](https://github.com/redis-developer/redis-enterprise-rs/pull/3))
+
+### Other
+
+- cleanup README and Python bindings ([#15](https://github.com/redis-developer/redis-enterprise-rs/pull/15))
+- split database tests into modular structure ([#14](https://github.com/redis-developer/redis-enterprise-rs/pull/14))
+- reduce handler boilerplate with macros ([#13](https://github.com/redis-developer/redis-enterprise-rs/pull/13))
+- remove extra: Value fields from all response types ([#11](https://github.com/redis-developer/redis-enterprise-rs/pull/11))
+
 ## [0.7.5](https://github.com/redis-developer/redis-enterprise-rs/compare/v0.7.4...v0.7.5) - 2026-01-30
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1049,7 +1049,7 @@ dependencies = [
 
 [[package]]
 name = "redis-enterprise"
-version = "0.7.5"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "redis-enterprise"
-version = "0.7.5"
+version = "0.8.0"
 edition = "2024"
 rust-version = "1.85"
 authors = ["Josh Rotenberg <joshrotenberg@gmail.com>"]


### PR DESCRIPTION



## 🤖 New release

* `redis-enterprise`: 0.7.5 -> 0.8.0 (⚠ API breaking changes)

### ⚠ `redis-enterprise` breaking changes

```text
--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/enum_variant_added.ron

Failed in:
  variant RestError:Timeout in /tmp/.tmp1XCMaZ/redis-enterprise-rs/src/error.rs:45
  variant RestError:RateLimited in /tmp/.tmp1XCMaZ/redis-enterprise-rs/src/error.rs:48
  variant RestError:AlreadyExists in /tmp/.tmp1XCMaZ/redis-enterprise-rs/src/error.rs:51
  variant RestError:Conflict in /tmp/.tmp1XCMaZ/redis-enterprise-rs/src/error.rs:54
  variant RestError:ClusterBusy in /tmp/.tmp1XCMaZ/redis-enterprise-rs/src/error.rs:57
  variant RestError:Timeout in /tmp/.tmp1XCMaZ/redis-enterprise-rs/src/error.rs:45
  variant RestError:RateLimited in /tmp/.tmp1XCMaZ/redis-enterprise-rs/src/error.rs:48
  variant RestError:AlreadyExists in /tmp/.tmp1XCMaZ/redis-enterprise-rs/src/error.rs:51
  variant RestError:Conflict in /tmp/.tmp1XCMaZ/redis-enterprise-rs/src/error.rs:54
  variant RestError:ClusterBusy in /tmp/.tmp1XCMaZ/redis-enterprise-rs/src/error.rs:57

--- failure struct_pub_field_missing: pub struct's pub field removed or renamed ---

Description:
A publicly-visible struct has at least one public field that is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/struct_pub_field_missing.ron

Failed in:
  field version of struct ClusterInfo, previously in file /tmp/.tmpaAyys3/redis-enterprise/src/cluster.rs:99
  field extra of struct ClusterInfo, previously in file /tmp/.tmpaAyys3/redis-enterprise/src/cluster.rs:344
  field version of struct ClusterInfo, previously in file /tmp/.tmpaAyys3/redis-enterprise/src/cluster.rs:99
  field extra of struct ClusterInfo, previously in file /tmp/.tmpaAyys3/redis-enterprise/src/cluster.rs:344
  field extra of struct BootstrapConfig, previously in file /tmp/.tmpaAyys3/redis-enterprise/src/bootstrap.rs:29
  field extra of struct BootstrapConfig, previously in file /tmp/.tmpaAyys3/redis-enterprise/src/bootstrap.rs:29
  field extra of struct ExportResponse, previously in file /tmp/.tmpaAyys3/redis-enterprise/src/bdb.rs:139
  field extra of struct NodeUsage, previously in file /tmp/.tmpaAyys3/redis-enterprise/src/usage_report.rs:78
  field extra of struct NodeUsage, previously in file /tmp/.tmpaAyys3/redis-enterprise/src/usage_report.rs:78
  field extra of struct LicenseInfo, previously in file /tmp/.tmpaAyys3/redis-enterprise/src/cluster.rs:691
  field extra of struct LicenseInfo, previously in file /tmp/.tmpaAyys3/redis-enterprise/src/cluster.rs:691
  field extra of struct BdbGroup, previously in file /tmp/.tmpaAyys3/redis-enterprise/src/bdb_groups.rs:28
  field extra of struct BdbGroup, previously in file /tmp/.tmpaAyys3/redis-enterprise/src/bdb_groups.rs:28
  field extra of struct AggregatedStatsResponse, previously in file /tmp/.tmpaAyys3/redis-enterprise/src/stats.rs:127
  field extra of struct OcspStatus, previously in file /tmp/.tmpaAyys3/redis-enterprise/src/ocsp.rs:60
  field extra of struct OcspStatus, previously in file /tmp/.tmpaAyys3/redis-enterprise/src/ocsp.rs:60
  field extra of struct ImportResponse, previously in file /tmp/.tmpaAyys3/redis-enterprise/src/bdb.rs:126
  field extra of struct NodeStats, previously in file /tmp/.tmpaAyys3/redis-enterprise/src/nodes.rs:145
  field extra of struct NodeStats, previously in file /tmp/.tmpaAyys3/redis-enterprise/src/nodes.rs:145
  field extra of struct CrdbTask, previously in file /tmp/.tmpaAyys3/redis-enterprise/src/crdb_tasks.rs:39
  field extra of struct CrdbTask, previously in file /tmp/.tmpaAyys3/redis-enterprise/src/crdb_tasks.rs:39
  field extra of struct License, previously in file /tmp/.tmpaAyys3/redis-enterprise/src/license.rs:77
  field extra of struct License, previously in file /tmp/.tmpaAyys3/redis-enterprise/src/license.rs:77
  field extra of struct EndpointInfo, previously in file /tmp/.tmpaAyys3/redis-enterprise/src/bdb.rs:456
  field extra of struct MetricResponse, previously in file /tmp/.tmpaAyys3/redis-enterprise/src/proxies.rs:20
  field extra of struct BackupResponse, previously in file /tmp/.tmpaAyys3/redis-enterprise/src/bdb.rs:113
  field extra of struct DbAlertsSettings, previously in file /tmp/.tmpaAyys3/redis-enterprise/src/alerts.rs:155
  field extra of struct EndpointStats, previously in file /tmp/.tmpaAyys3/redis-enterprise/src/endpoints.rs:47
  field extra of struct EndpointStats, previously in file /tmp/.tmpaAyys3/redis-enterprise/src/endpoints.rs:47
  field extra of struct ClusterAlertsSettings, previously in file /tmp/.tmpaAyys3/redis-enterprise/src/alerts.rs:217
  field extra of struct MetricResponse, previously in file /tmp/.tmpaAyys3/redis-enterprise/src/shards.rs:20
  field extra of struct LdapConfig, previously in file /tmp/.tmpaAyys3/redis-enterprise/src/ldap_mappings.rs:83
  field extra of struct LdapConfig, previously in file /tmp/.tmpaAyys3/redis-enterprise/src/ldap_mappings.rs:83
  field extra of struct DatabaseActionResponse, previously in file /tmp/.tmpaAyys3/redis-enterprise/src/bdb.rs:100
  field extra of struct Action, previously in file /tmp/.tmpaAyys3/redis-enterprise/src/shards.rs:160
  field extra of struct CmSettings, previously in file /tmp/.tmpaAyys3/redis-enterprise/src/cm_settings.rs:39
  field extra of struct CmSettings, previously in file /tmp/.tmpaAyys3/redis-enterprise/src/cm_settings.rs:39
  field extra of struct ScheduledJob, previously in file /tmp/.tmpaAyys3/redis-enterprise/src/job_scheduler.rs:39
  field extra of struct ScheduledJob, previously in file /tmp/.tmpaAyys3/redis-enterprise/src/job_scheduler.rs:39
  field extra of struct Shard, previously in file /tmp/.tmpaAyys3/redis-enterprise/src/shards.rs:51
  field extra of struct Shard, previously in file /tmp/.tmpaAyys3/redis-enterprise/src/shards.rs:51
  field extra of struct Role, previously in file /tmp/.tmpaAyys3/redis-enterprise/src/users.rs:160
  field extra of struct Role, previously in file /tmp/.tmpaAyys3/redis-enterprise/src/users.rs:160
  field extra of struct AclValidation, previously in file /tmp/.tmpaAyys3/redis-enterprise/src/redis_acls.rs:94
  field extra of struct DiagnosticReport, previously in file /tmp/.tmpaAyys3/redis-enterprise/src/diagnostics.rs:66
  field extra of struct DiagnosticReport, previously in file /tmp/.tmpaAyys3/redis-enterprise/src/diagnostics.rs:66
  field extra of struct Node, previously in file /tmp/.tmpaAyys3/redis-enterprise/src/nodes.rs:128
  field extra of struct Node, previously in file /tmp/.tmpaAyys3/redis-enterprise/src/nodes.rs:128
  field extra of struct DatabaseInfo, previously in file /tmp/.tmpaAyys3/redis-enterprise/src/bdb.rs:430
  field extra of struct DatabaseInfo, previously in file /tmp/.tmpaAyys3/redis-enterprise/src/bdb.rs:430
  field extra of struct DatabaseInfo, previously in file /tmp/.tmpaAyys3/redis-enterprise/src/bdb.rs:430
  field extra of struct Service, previously in file /tmp/.tmpaAyys3/redis-enterprise/src/services.rs:36
  field extra of struct Service, previously in file /tmp/.tmpaAyys3/redis-enterprise/src/services.rs:36
  field extra of struct JobExecution, previously in file /tmp/.tmpaAyys3/redis-enterprise/src/job_scheduler.rs:83
  field extra of struct JobExecution, previously in file /tmp/.tmpaAyys3/redis-enterprise/src/job_scheduler.rs:83
  field extra of struct DiagnosticResult, previously in file /tmp/.tmpaAyys3/redis-enterprise/src/diagnostics.rs:49
  field extra of struct DiagnosticResult, previously in file /tmp/.tmpaAyys3/redis-enterprise/src/diagnostics.rs:49
  field extra of struct OcspConfig, previously in file /tmp/.tmpaAyys3/redis-enterprise/src/ocsp.rs:35
  field extra of struct OcspConfig, previously in file /tmp/.tmpaAyys3/redis-enterprise/src/ocsp.rs:35
  field extra of struct AuthResponse, previously in file /tmp/.tmpaAyys3/redis-enterprise/src/users.rs:253
  field extra of struct Alert, previously in file /tmp/.tmpaAyys3/redis-enterprise/src/alerts.rs:51
  field extra of struct Alert, previously in file /tmp/.tmpaAyys3/redis-enterprise/src/alerts.rs:51
  field extra of struct Action, previously in file /tmp/.tmpaAyys3/redis-enterprise/src/actions.rs:41
  field extra of struct Action, previously in file /tmp/.tmpaAyys3/redis-enterprise/src/actions.rs:41
  field extra of struct ServiceStatus, previously in file /tmp/.tmpaAyys3/redis-enterprise/src/services.rs:69
  field extra of struct ServiceStatus, previously in file /tmp/.tmpaAyys3/redis-enterprise/src/services.rs:69
  field extra of struct LdapMapping, previously in file /tmp/.tmpaAyys3/redis-enterprise/src/ldap_mappings.rs:33
  field extra of struct LdapMapping, previously in file /tmp/.tmpaAyys3/redis-enterprise/src/ldap_mappings.rs:33
  field extra of struct BootstrapStatus, previously in file /tmp/.tmpaAyys3/redis-enterprise/src/bootstrap.rs:86
  field extra of struct BootstrapStatus, previously in file /tmp/.tmpaAyys3/redis-enterprise/src/bootstrap.rs:86
  field extra of struct NodeActionResponse, previously in file /tmp/.tmpaAyys3/redis-enterprise/src/nodes.rs:23
  field extra of struct LogEntry, previously in file /tmp/.tmpaAyys3/redis-enterprise/src/logs.rs:32
  field extra of struct LogEntry, previously in file /tmp/.tmpaAyys3/redis-enterprise/src/logs.rs:32
  field extra of struct ProxyStats, previously in file /tmp/.tmpaAyys3/redis-enterprise/src/proxies.rs:143
  field extra of struct ProxyStats, previously in file /tmp/.tmpaAyys3/redis-enterprise/src/proxies.rs:143
  field extra of struct Migration, previously in file /tmp/.tmpaAyys3/redis-enterprise/src/migrations.rs:39
  field extra of struct Migration, previously in file /tmp/.tmpaAyys3/redis-enterprise/src/migrations.rs:39
  field extra of struct ClusterActionResponse, previously in file /tmp/.tmpaAyys3/redis-enterprise/src/cluster.rs:65
  field extra of struct Endpoint, previously in file /tmp/.tmpaAyys3/redis-enterprise/src/endpoints.rs:37
  field extra of struct Endpoint, previously in file /tmp/.tmpaAyys3/redis-enterprise/src/endpoints.rs:37
  field extra of struct ShardActionRequest, previously in file /tmp/.tmpaAyys3/redis-enterprise/src/shards.rs:151
  field extra of struct DatabaseUsage, previously in file /tmp/.tmpaAyys3/redis-enterprise/src/usage_report.rs:60
  field extra of struct DatabaseUsage, previously in file /tmp/.tmpaAyys3/redis-enterprise/src/usage_report.rs:60
  field extra of struct Suffix, previously in file /tmp/.tmpaAyys3/redis-enterprise/src/suffixes.rs:30
  field extra of struct Suffix, previously in file /tmp/.tmpaAyys3/redis-enterprise/src/suffixes.rs:30
  field extra of struct NodeInfo, previously in file /tmp/.tmpaAyys3/redis-enterprise/src/cluster.rs:678
  field extra of struct NodeInfo, previously in file /tmp/.tmpaAyys3/redis-enterprise/src/cluster.rs:678
  field extra of struct DebugInfoStatus, previously in file /tmp/.tmpaAyys3/redis-enterprise/src/debuginfo.rs:70
  field extra of struct DebugInfoStatus, previously in file /tmp/.tmpaAyys3/redis-enterprise/src/debuginfo.rs:70
  field extra of struct LicenseUsage, previously in file /tmp/.tmpaAyys3/redis-enterprise/src/license.rs:107
  field extra of struct LicenseUsage, previously in file /tmp/.tmpaAyys3/redis-enterprise/src/license.rs:107
  field extra of struct OcspTestResult, previously in file /tmp/.tmpaAyys3/redis-enterprise/src/ocsp.rs:76
  field extra of struct OcspTestResult, previously in file /tmp/.tmpaAyys3/redis-enterprise/src/ocsp.rs:76
  field extra of struct ResourceStats, previously in file /tmp/.tmpaAyys3/redis-enterprise/src/stats.rs:138
  field extra of struct Module, previously in file /tmp/.tmpaAyys3/redis-enterprise/src/modules.rs:62
  field extra of struct Module, previously in file /tmp/.tmpaAyys3/redis-enterprise/src/modules.rs:62
  field extra of struct CrdbInstance, previously in file /tmp/.tmpaAyys3/redis-enterprise/src/crdb.rs:55
  field extra of struct CrdbInstance, previously in file /tmp/.tmpaAyys3/redis-enterprise/src/crdb.rs:55
  field extra of struct UsageReport, previously in file /tmp/.tmpaAyys3/redis-enterprise/src/usage_report.rs:37
  field extra of struct UsageReport, previously in file /tmp/.tmpaAyys3/redis-enterprise/src/usage_report.rs:37
  field extra of struct RoleInfo, previously in file /tmp/.tmpaAyys3/redis-enterprise/src/roles.rs:29
  field extra of struct RoleInfo, previously in file /tmp/.tmpaAyys3/redis-enterprise/src/roles.rs:29
  field extra of struct Crdb, previously in file /tmp/.tmpaAyys3/redis-enterprise/src/crdb.rs:37
  field extra of struct Crdb, previously in file /tmp/.tmpaAyys3/redis-enterprise/src/crdb.rs:37
  field extra of struct ProxyUpdate, previously in file /tmp/.tmpaAyys3/redis-enterprise/src/proxies.rs:227
  field extra of struct ClusterNode, previously in file /tmp/.tmpaAyys3/redis-enterprise/src/cluster.rs:80
  field extra of struct ClusterNode, previously in file /tmp/.tmpaAyys3/redis-enterprise/src/cluster.rs:80
  field extra of struct RedisAcl, previously in file /tmp/.tmpaAyys3/redis-enterprise/src/redis_acls.rs:27
  field extra of struct RedisAcl, previously in file /tmp/.tmpaAyys3/redis-enterprise/src/redis_acls.rs:27
  field extra of struct ShardStats, previously in file /tmp/.tmpaAyys3/redis-enterprise/src/shards.rs:61
  field extra of struct ShardStats, previously in file /tmp/.tmpaAyys3/redis-enterprise/src/shards.rs:61
  field extra of struct Proxy, previously in file /tmp/.tmpaAyys3/redis-enterprise/src/proxies.rs:133
  field extra of struct Proxy, previously in file /tmp/.tmpaAyys3/redis-enterprise/src/proxies.rs:133
  field extra of struct ClusterSettings, previously in file /tmp/.tmpaAyys3/redis-enterprise/src/cluster.rs:421
  field extra of struct User, previously in file /tmp/.tmpaAyys3/redis-enterprise/src/users.rs:52
  field extra of struct User, previously in file /tmp/.tmpaAyys3/redis-enterprise/src/users.rs:52
  field extra of struct StatsResponse, previously in file /tmp/.tmpaAyys3/redis-enterprise/src/stats.rs:94
  field extra of struct StatsResponse, previously in file /tmp/.tmpaAyys3/redis-enterprise/src/stats.rs:94
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.8.0](https://github.com/redis-developer/redis-enterprise-rs/compare/v0.7.5...v0.8.0) - 2026-01-30

### Added

- add more specific error variants ([#12](https://github.com/redis-developer/redis-enterprise-rs/pull/12))
- add fluent API and align with redis-cloud patterns ([#10](https://github.com/redis-developer/redis-enterprise-rs/pull/10))

### Fixed

- add README to PyPI package ([#3](https://github.com/redis-developer/redis-enterprise-rs/pull/3))

### Other

- cleanup README and Python bindings ([#15](https://github.com/redis-developer/redis-enterprise-rs/pull/15))
- split database tests into modular structure ([#14](https://github.com/redis-developer/redis-enterprise-rs/pull/14))
- reduce handler boilerplate with macros ([#13](https://github.com/redis-developer/redis-enterprise-rs/pull/13))
- remove extra: Value fields from all response types ([#11](https://github.com/redis-developer/redis-enterprise-rs/pull/11))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).