### PR TITLE
refactor: remove extra: Value fields from all response types

### DIFF
--- a/src/actions.rs
+++ b/src/actions.rs
@@ -8,7 +8,6 @@
 use crate::client::RestClient;
 use crate::error::Result;
 use serde::{Deserialize, Serialize};
-use serde_json::Value;
 
 /// Action information
 /// Represents an action (operation) in the cluster
@@ -36,9 +35,6 @@ pub struct Action {
     pub bdb_uid: Option<u32>,
     /// Node UID associated with the action
     pub node_uid: Option<u32>,
-
-    #[serde(flatten)]
-    pub extra: Value,
 }
 
 /// Action handler for tracking async operations

--- a/src/alerts.rs
+++ b/src/alerts.rs
@@ -46,9 +46,6 @@ pub struct Alert {
     /// Error code associated with the alert
     #[serde(skip_serializing_if = "Option::is_none")]
     pub error_code: Option<String>,
-
-    #[serde(flatten)]
-    pub extra: Value,
 }
 
 /// Generic alert settings (legacy - kept for compatibility)
@@ -150,9 +147,6 @@ pub struct DbAlertsSettings {
     /// (Deprecated) Replica of - sync encountered in general error
     #[serde(skip_serializing_if = "Option::is_none")]
     pub bdb_syncer_general_error: Option<BdbAlertSettingsWithThreshold>,
-
-    #[serde(flatten)]
-    pub extra: Value,
 }
 
 /// Cluster alert settings with threshold
@@ -212,9 +206,6 @@ pub struct ClusterAlertsSettings {
     /// Node persistent storage below threshold
     #[serde(skip_serializing_if = "Option::is_none")]
     pub node_persistent_storage: Option<ClusterAlertSettingsWithThreshold>,
-
-    #[serde(flatten)]
-    pub extra: Value,
 }
 
 /// Alert handler for managing alerts

--- a/src/bdb.rs
+++ b/src/bdb.rs
@@ -90,9 +90,6 @@ pub struct DatabaseActionResponse {
     pub action_uid: String,
     /// Description of the action
     pub description: Option<String>,
-    /// Additional fields from the response
-    #[serde(flatten)]
-    pub extra: Value,
 }
 
 /// Response from backup operation
@@ -103,9 +100,6 @@ pub struct BackupResponse {
     pub action_uid: Option<String>,
     /// Backup UID if available
     pub backup_uid: Option<String>,
-    /// Additional fields from the response
-    #[serde(flatten)]
-    pub extra: Value,
 }
 
 /// Response from import operation
@@ -116,9 +110,6 @@ pub struct ImportResponse {
     pub action_uid: Option<String>,
     /// Import status
     pub status: Option<String>,
-    /// Additional fields from the response
-    #[serde(flatten)]
-    pub extra: Value,
 }
 
 /// Response from export operation
@@ -129,9 +120,6 @@ pub struct ExportResponse {
     pub action_uid: Option<String>,
     /// Export status
     pub status: Option<String>,
-    /// Additional fields from the response
-    #[serde(flatten)]
-    pub extra: Value,
 }
 
 /// Module information for database upgrade
@@ -419,10 +407,6 @@ pub struct DatabaseInfo {
     pub roles_permissions: Option<Vec<Value>>,
     pub tags: Option<Vec<String>>,
     pub topology_epoch: Option<u32>,
-
-    /// Capture any additional fields not explicitly defined
-    #[serde(flatten)]
-    pub extra: Value,
 }
 
 /// Database endpoint information
@@ -446,9 +430,6 @@ pub struct EndpointInfo {
     pub exclude_proxies: Option<Vec<u32>>,
     /// List of proxy UIDs to include
     pub include_proxies: Option<Vec<u32>>,
-    /// Capture any additional fields
-    #[serde(flatten)]
-    pub extra: Value,
 }
 
 /// Module configuration for database creation

--- a/src/bdb_groups.rs
+++ b/src/bdb_groups.rs
@@ -8,7 +8,6 @@
 use crate::client::RestClient;
 use crate::error::Result;
 use serde::{Deserialize, Serialize};
-use serde_json::Value;
 
 /// Database group information
 /// Represents a group of databases that share a memory pool
@@ -24,8 +23,6 @@ pub struct BdbGroup {
     /// A list of UIDs of member databases (read-only)
     #[serde(skip_serializing_if = "Option::is_none")]
     pub members: Option<Vec<String>>,
-    #[serde(flatten)]
-    pub extra: Value,
 }
 
 /// Handler for database group operations

--- a/src/bootstrap.rs
+++ b/src/bootstrap.rs
@@ -24,9 +24,6 @@ pub struct BootstrapConfig {
     #[serde(skip_serializing_if = "Option::is_none")]
     /// Admin credentials for cluster access
     pub credentials: Option<CredentialsBootstrap>,
-
-    #[serde(flatten)]
-    pub extra: Value,
 }
 
 /// Cluster bootstrap configuration
@@ -81,9 +78,6 @@ pub struct BootstrapStatus {
     #[serde(skip_serializing_if = "Option::is_none")]
     /// Status message or error description
     pub message: Option<String>,
-
-    #[serde(flatten)]
-    pub extra: Value,
 }
 
 /// Bootstrap handler for cluster initialization

--- a/src/cluster.rs
+++ b/src/cluster.rs
@@ -56,9 +56,6 @@ pub struct ClusterActionResponse {
     pub action_uid: String,
     /// Description of the action
     pub description: Option<String>,
-    /// Additional fields from the response
-    #[serde(flatten)]
-    pub extra: Value,
 }
 
 /// Node information
@@ -71,9 +68,6 @@ pub struct ClusterNode {
     pub total_memory: Option<u64>,
     pub used_memory: Option<u64>,
     pub cpu_cores: Option<u32>,
-
-    #[serde(flatten)]
-    pub extra: Value,
 }
 
 /// Cluster information from the REST API
@@ -332,9 +326,6 @@ pub struct ClusterInfo {
 
     /// Wait command support
     pub wait_command: Option<bool>,
-
-    #[serde(flatten)]
-    pub extra: Value,
 }
 
 /// Cluster-wide settings configuration (57 fields)
@@ -409,9 +400,6 @@ pub struct ClusterSettings {
     pub show_internals: Option<bool>,
     pub slave_threads_when_master: Option<bool>,
     pub use_empty_shard_backups: Option<bool>,
-
-    #[serde(flatten)]
-    pub extra: Value,
 }
 
 /// Bootstrap request for creating a new cluster
@@ -666,9 +654,6 @@ pub struct NodeInfo {
     pub shards: Option<Vec<u32>>,
     pub total_memory: Option<u64>,
     pub used_memory: Option<u64>,
-
-    #[serde(flatten)]
-    pub extra: Value,
 }
 
 /// License information
@@ -679,7 +664,4 @@ pub struct LicenseInfo {
     pub expiration_date: Option<String>,
     pub shards_limit: Option<u32>,
     pub features: Option<Vec<String>>,
-
-    #[serde(flatten)]
-    pub extra: Value,
 }

--- a/src/cm_settings.rs
+++ b/src/cm_settings.rs
@@ -8,7 +8,6 @@
 use crate::client::RestClient;
 use crate::error::Result;
 use serde::{Deserialize, Serialize};
-use serde_json::Value;
 
 /// Cluster Manager settings
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -34,9 +33,6 @@ pub struct CmSettings {
     /// Maximum number of simultaneous backup operations allowed
     #[serde(skip_serializing_if = "Option::is_none")]
     pub max_simultaneous_backups: Option<u32>,
-
-    #[serde(flatten)]
-    pub extra: Value,
 }
 
 /// Cluster Manager settings handler

--- a/src/crdb.rs
+++ b/src/crdb.rs
@@ -32,9 +32,6 @@ pub struct Crdb {
     pub replication: Option<bool>,
     /// Data eviction policy (e.g., 'allkeys-lru', 'volatile-lru')
     pub eviction_policy: Option<String>,
-
-    #[serde(flatten)]
-    pub extra: Value,
 }
 
 /// CRDB instance information
@@ -50,9 +47,6 @@ pub struct CrdbInstance {
     pub status: String,
     /// List of endpoint addresses for this instance
     pub endpoints: Option<Vec<String>>,
-
-    #[serde(flatten)]
-    pub extra: Value,
 }
 
 /// Create CRDB request

--- a/src/crdb_tasks.rs
+++ b/src/crdb_tasks.rs
@@ -34,9 +34,6 @@ pub struct CrdbTask {
     /// Error description if the task failed
     #[serde(skip_serializing_if = "Option::is_none")]
     pub error: Option<String>,
-
-    #[serde(flatten)]
-    pub extra: Value,
 }
 
 /// CRDB task creation request

--- a/src/debuginfo.rs
+++ b/src/debuginfo.rs
@@ -65,9 +65,6 @@ pub struct DebugInfoStatus {
     /// Error description if the collection task failed
     #[serde(skip_serializing_if = "Option::is_none")]
     pub error: Option<String>,
-
-    #[serde(flatten)]
-    pub extra: Value,
 }
 
 /// Debug info handler

--- a/src/diagnostics.rs
+++ b/src/diagnostics.rs
@@ -44,9 +44,6 @@ pub struct DiagnosticResult {
     /// Recommended actions to resolve any issues found
     #[serde(skip_serializing_if = "Option::is_none")]
     pub recommendations: Option<Vec<String>>,
-
-    #[serde(flatten)]
-    pub extra: Value,
 }
 
 /// Diagnostic report
@@ -61,9 +58,6 @@ pub struct DiagnosticReport {
     /// Summary statistics of the diagnostic run
     #[serde(skip_serializing_if = "Option::is_none")]
     pub summary: Option<DiagnosticSummary>,
-
-    #[serde(flatten)]
-    pub extra: Value,
 }
 
 /// Diagnostic summary

--- a/src/endpoints.rs
+++ b/src/endpoints.rs
@@ -32,9 +32,6 @@ pub struct Endpoint {
     /// Error code if endpoint has an error
     #[serde(skip_serializing_if = "Option::is_none")]
     pub error_code: Option<String>,
-
-    #[serde(flatten)]
-    pub extra: Value,
 }
 
 /// Endpoint statistics
@@ -42,9 +39,6 @@ pub struct Endpoint {
 pub struct EndpointStats {
     pub uid: String,
     pub intervals: Vec<StatsInterval>,
-
-    #[serde(flatten)]
-    pub extra: Value,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src/job_scheduler.rs
+++ b/src/job_scheduler.rs
@@ -34,9 +34,6 @@ pub struct ScheduledJob {
     /// Job-specific parameters and configuration
     #[serde(skip_serializing_if = "Option::is_none")]
     pub params: Option<Value>,
-
-    #[serde(flatten)]
-    pub extra: Value,
 }
 
 /// Create scheduled job request
@@ -78,9 +75,6 @@ pub struct JobExecution {
     /// Error description if the job execution failed
     #[serde(skip_serializing_if = "Option::is_none")]
     pub error: Option<String>,
-
-    #[serde(flatten)]
-    pub extra: Value,
 }
 
 /// Job scheduler handler

--- a/src/ldap_mappings.rs
+++ b/src/ldap_mappings.rs
@@ -8,7 +8,6 @@
 use crate::client::RestClient;
 use crate::error::Result;
 use serde::{Deserialize, Serialize};
-use serde_json::Value;
 use typed_builder::TypedBuilder;
 
 /// LDAP mapping information
@@ -28,9 +27,6 @@ pub struct LdapMapping {
     /// List of role uids associated with the LDAP group
     #[serde(skip_serializing_if = "Option::is_none")]
     pub role_uids: Option<Vec<u32>>,
-
-    #[serde(flatten)]
-    pub extra: Value,
 }
 
 /// Create or update LDAP mapping request
@@ -78,9 +74,6 @@ pub struct LdapConfig {
     /// Password for LDAP binding
     #[serde(skip_serializing_if = "Option::is_none")]
     pub bind_pass: Option<String>,
-
-    #[serde(flatten)]
-    pub extra: Value,
 }
 
 /// LDAP server configuration

--- a/src/lib_tests.rs
+++ b/src/lib_tests.rs
@@ -199,7 +199,7 @@ mod tests {
             .and(basic_auth("admin", "password"))
             .respond_with(
                 ResponseTemplate::new(200)
-                    .set_body_json(serde_json::json!({"task_id": "export-123"})),
+                    .set_body_json(serde_json::json!({"action_uid": "export-123"})),
             )
             .mount(&mock_server)
             .await;
@@ -215,8 +215,7 @@ mod tests {
         let result = handler.export(1, "ftp://backup/db1.rdb").await;
 
         assert!(result.is_ok());
-        // ExportResponse doesn't have task_id, check action_uid instead
-        assert!(result.unwrap().extra["task_id"].is_string());
+        assert!(result.unwrap().action_uid.is_some());
     }
 
     #[tokio::test]
@@ -228,7 +227,7 @@ mod tests {
             .and(basic_auth("admin", "password"))
             .respond_with(
                 ResponseTemplate::new(200)
-                    .set_body_json(serde_json::json!({"task_id": "import-456"})),
+                    .set_body_json(serde_json::json!({"action_uid": "import-456"})),
             )
             .mount(&mock_server)
             .await;
@@ -244,8 +243,7 @@ mod tests {
         let result = handler.import(1, "ftp://backup/db1.rdb", true).await;
 
         assert!(result.is_ok());
-        // ImportResponse doesn't have task_id, check action_uid instead
-        assert!(result.unwrap().extra["task_id"].is_string());
+        assert!(result.unwrap().action_uid.is_some());
     }
 
     #[tokio::test]
@@ -257,7 +255,7 @@ mod tests {
             .and(basic_auth("admin", "password"))
             .respond_with(
                 ResponseTemplate::new(200)
-                    .set_body_json(serde_json::json!({"backup_id": "backup-789"})),
+                    .set_body_json(serde_json::json!({"backup_uid": "backup-789"})),
             )
             .mount(&mock_server)
             .await;
@@ -273,8 +271,7 @@ mod tests {
         let result = handler.backup(1).await;
 
         assert!(result.is_ok());
-        // BackupResponse has backup_uid field
-        assert!(result.unwrap().extra["backup_id"].is_string());
+        assert!(result.unwrap().backup_uid.is_some());
     }
 
     #[tokio::test]

--- a/src/license.rs
+++ b/src/license.rs
@@ -8,7 +8,6 @@
 use crate::client::RestClient;
 use crate::error::Result;
 use serde::{Deserialize, Serialize};
-use serde_json::Value;
 use typed_builder::TypedBuilder;
 
 /// License information
@@ -72,9 +71,6 @@ pub struct License {
     /// List of features supported by license
     #[serde(skip_serializing_if = "Option::is_none")]
     pub features: Option<Vec<String>>,
-
-    #[serde(flatten)]
-    pub extra: Value,
 }
 
 /// License update request
@@ -102,9 +98,6 @@ pub struct LicenseUsage {
     /// Maximum amount of RAM allowed by license (bytes)
     #[serde(skip_serializing_if = "Option::is_none")]
     pub ram_limit: Option<u64>,
-
-    #[serde(flatten)]
-    pub extra: Value,
 }
 
 /// License handler

--- a/src/logs.rs
+++ b/src/logs.rs
@@ -10,7 +10,6 @@ use crate::client::RestClient;
 use crate::error::Result;
 use futures::stream::Stream;
 use serde::{Deserialize, Serialize};
-use serde_json::Value;
 use std::pin::Pin;
 use std::time::Duration;
 use tokio::time::sleep;
@@ -25,11 +24,6 @@ pub struct LogEntry {
     /// (e.g., "bdb_name_updated", "node_status_changed", etc.)
     #[serde(rename = "type")]
     pub event_type: String,
-
-    /// Additional fields based on event type
-    /// May include severity, bdb_uid, old_val, new_val, and other event-specific fields
-    #[serde(flatten)]
-    pub extra: Value,
 }
 
 /// Logs query parameters

--- a/src/migrations.rs
+++ b/src/migrations.rs
@@ -34,9 +34,6 @@ pub struct Migration {
     /// Error message if migration failed
     #[serde(skip_serializing_if = "Option::is_none")]
     pub error: Option<String>,
-
-    #[serde(flatten)]
-    pub extra: Value,
 }
 
 /// Migration endpoint configuration

--- a/src/modules.rs
+++ b/src/modules.rs
@@ -57,9 +57,6 @@ pub struct Module {
 
     /// SHA256 checksum of the module binary for verification
     pub sha256: Option<String>,
-
-    #[serde(flatten)]
-    pub extra: Value,
 }
 
 /// Module handler for managing Redis modules

--- a/src/nodes.rs
+++ b/src/nodes.rs
@@ -18,9 +18,6 @@ pub struct NodeActionResponse {
     pub action_uid: String,
     /// Description of the action
     pub description: Option<String>,
-    /// Additional fields from the response
-    #[serde(flatten)]
-    pub extra: Value,
 }
 
 /// Node information
@@ -122,10 +119,6 @@ pub struct Node {
 
     /// Recovery files path
     pub recovery_path: Option<String>,
-
-    /// Capture any additional fields not explicitly defined
-    #[serde(flatten)]
-    pub extra: Value,
 }
 
 /// Node stats
@@ -140,9 +133,6 @@ pub struct NodeStats {
     pub network_bytes_out: Option<u64>,
     pub persistent_storage_free: Option<u64>,
     pub ephemeral_storage_free: Option<u64>,
-
-    #[serde(flatten)]
-    pub extra: Value,
 }
 
 /// Node action request

--- a/src/ocsp.rs
+++ b/src/ocsp.rs
@@ -30,9 +30,6 @@ pub struct OcspConfig {
     /// Maximum number of recovery attempts
     #[serde(skip_serializing_if = "Option::is_none")]
     pub recovery_max_tries: Option<u32>,
-
-    #[serde(flatten)]
-    pub extra: Value,
 }
 
 /// OCSP status information
@@ -55,9 +52,6 @@ pub struct OcspStatus {
     /// Reason for certificate revocation (if revoked)
     #[serde(skip_serializing_if = "Option::is_none")]
     pub revocation_reason: Option<String>,
-
-    #[serde(flatten)]
-    pub extra: Value,
 }
 
 /// OCSP test result
@@ -71,9 +65,6 @@ pub struct OcspTestResult {
     /// Response time from OCSP server in milliseconds
     #[serde(skip_serializing_if = "Option::is_none")]
     pub response_time_ms: Option<u32>,
-
-    #[serde(flatten)]
-    pub extra: Value,
 }
 
 /// OCSP handler for managing OCSP configuration

--- a/src/proxies.rs
+++ b/src/proxies.rs
@@ -16,8 +16,6 @@ pub struct MetricResponse {
     pub interval: String,
     pub timestamps: Vec<i64>,
     pub values: Vec<Value>,
-    #[serde(flatten)]
-    pub extra: Value,
 }
 
 /// Proxy information
@@ -128,9 +126,6 @@ pub struct Proxy {
     /// CPU usage threshold percentage for thread scaling decisions
     #[serde(skip_serializing_if = "Option::is_none")]
     pub threads_usage_threshold: Option<u32>,
-
-    #[serde(flatten)]
-    pub extra: Value,
 }
 
 /// Proxy stats information
@@ -138,9 +133,6 @@ pub struct Proxy {
 pub struct ProxyStats {
     pub uid: u32,
     pub intervals: Vec<StatsInterval>,
-
-    #[serde(flatten)]
-    pub extra: Value,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -223,6 +215,4 @@ pub struct ProxyUpdate {
     pub max_connections: Option<u32>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub threads: Option<u32>,
-    #[serde(flatten)]
-    pub extra: Value,
 }

--- a/src/redis_acls.rs
+++ b/src/redis_acls.rs
@@ -8,7 +8,6 @@
 use crate::client::RestClient;
 use crate::error::Result;
 use serde::{Deserialize, Serialize};
-use serde_json::Value;
 use typed_builder::TypedBuilder;
 
 /// Redis ACL information
@@ -22,9 +21,6 @@ pub struct RedisAcl {
     /// List of database UIDs this ACL is associated with
     #[serde(skip_serializing_if = "Option::is_none")]
     pub bdbs: Option<Vec<u32>>,
-
-    #[serde(flatten)]
-    pub extra: Value,
 }
 
 /// Create or update Redis ACL request
@@ -90,6 +86,4 @@ pub struct AclValidation {
     pub valid: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub message: Option<String>,
-    #[serde(flatten)]
-    pub extra: Value,
 }

--- a/src/roles.rs
+++ b/src/roles.rs
@@ -8,7 +8,6 @@
 use crate::client::RestClient;
 use crate::error::Result;
 use serde::{Deserialize, Serialize};
-use serde_json::Value;
 use typed_builder::TypedBuilder;
 
 /// Role information
@@ -24,9 +23,6 @@ pub struct RoleInfo {
     pub bdb_roles: Option<Vec<BdbRole>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub cluster_roles: Option<Vec<String>>,
-
-    #[serde(flatten)]
-    pub extra: Value,
 }
 
 /// Database-specific role permissions

--- a/src/services.rs
+++ b/src/services.rs
@@ -31,9 +31,6 @@ pub struct Service {
     /// List of node UIDs where this service is running
     #[serde(skip_serializing_if = "Option::is_none")]
     pub node_uids: Option<Vec<u32>>,
-
-    #[serde(flatten)]
-    pub extra: Value,
 }
 
 /// Service configuration request
@@ -64,9 +61,6 @@ pub struct ServiceStatus {
     /// Status of the service on individual nodes
     #[serde(skip_serializing_if = "Option::is_none")]
     pub node_statuses: Option<Vec<NodeServiceStatus>>,
-
-    #[serde(flatten)]
-    pub extra: Value,
 }
 
 /// Node service status

--- a/src/shards.rs
+++ b/src/shards.rs
@@ -16,8 +16,6 @@ pub struct MetricResponse {
     pub interval: String,
     pub timestamps: Vec<i64>,
     pub values: Vec<Value>,
-    #[serde(flatten)]
-    pub extra: Value,
 }
 
 /// Shard information
@@ -46,9 +44,6 @@ pub struct Shard {
     pub redis_info: Option<Value>,
     /// Roles assigned to this shard
     pub roles: Option<Vec<String>>,
-
-    #[serde(flatten)]
-    pub extra: Value,
 }
 
 /// Shard stats information
@@ -56,9 +51,6 @@ pub struct Shard {
 pub struct ShardStats {
     pub uid: String,
     pub intervals: Vec<StatsInterval>,
-
-    #[serde(flatten)]
-    pub extra: Value,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -147,8 +139,6 @@ impl ShardHandler {
 pub struct ShardActionRequest {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub shard_uids: Option<Vec<String>>,
-    #[serde(flatten)]
-    pub extra: Value,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -156,6 +146,4 @@ pub struct Action {
     pub action_uid: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub status: Option<String>,
-    #[serde(flatten)]
-    pub extra: Value,
 }

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -85,9 +85,6 @@ pub struct StatsQuery {
 pub struct StatsResponse {
     /// Array of time intervals with their corresponding metrics
     pub intervals: Vec<StatsInterval>,
-
-    #[serde(flatten)]
-    pub extra: Value,
 }
 
 /// Stats interval
@@ -119,8 +116,6 @@ pub struct LastStatsResponse {
 pub struct AggregatedStatsResponse {
     /// Array of stats for individual resources (nodes, databases, shards)
     pub stats: Vec<ResourceStats>,
-    #[serde(flatten)]
-    pub extra: Value,
 }
 
 /// Stats for a single resource
@@ -130,8 +125,6 @@ pub struct ResourceStats {
     pub uid: u32,
     /// Time intervals with metrics for this specific resource
     pub intervals: Vec<StatsInterval>,
-    #[serde(flatten)]
-    pub extra: Value,
 }
 
 /// Stats handler for retrieving metrics

--- a/src/suffixes.rs
+++ b/src/suffixes.rs
@@ -8,7 +8,6 @@
 use crate::client::RestClient;
 use crate::error::Result;
 use serde::{Deserialize, Serialize};
-use serde_json::Value;
 use typed_builder::TypedBuilder;
 
 /// DNS suffix configuration
@@ -25,9 +24,6 @@ pub struct Suffix {
     /// Whether to use external addresses for this suffix
     #[serde(skip_serializing_if = "Option::is_none")]
     pub use_external_addr: Option<bool>,
-
-    #[serde(flatten)]
-    pub extra: Value,
 }
 
 /// Create suffix request

--- a/src/usage_report.rs
+++ b/src/usage_report.rs
@@ -32,9 +32,6 @@ pub struct UsageReport {
     /// Summary of overall usage across the cluster
     #[serde(skip_serializing_if = "Option::is_none")]
     pub summary: Option<UsageSummary>,
-
-    #[serde(flatten)]
-    pub extra: Value,
 }
 
 /// Database usage information
@@ -55,9 +52,6 @@ pub struct DatabaseUsage {
     /// Number of shards in the database
     #[serde(skip_serializing_if = "Option::is_none")]
     pub shard_count: Option<u32>,
-
-    #[serde(flatten)]
-    pub extra: Value,
 }
 
 /// Node usage information
@@ -73,9 +67,6 @@ pub struct NodeUsage {
     pub persistent_storage_usage: u64,
     /// Ephemeral storage usage (bytes)
     pub ephemeral_storage_usage: u64,
-
-    #[serde(flatten)]
-    pub extra: Value,
 }
 
 /// Usage summary

--- a/src/users.rs
+++ b/src/users.rs
@@ -47,9 +47,6 @@ pub struct User {
     pub alert_bdb_crdt_src_syncer: Option<bool>,
     /// Password expiration duration in seconds
     pub password_expiration_duration: Option<u32>,
-
-    #[serde(flatten)]
-    pub extra: Value,
 }
 
 /// Create user request
@@ -155,9 +152,6 @@ pub struct Role {
     pub name: String,
     pub management: Option<String>,
     pub data_access: Option<String>,
-
-    #[serde(flatten)]
-    pub extra: Value,
 }
 
 /// User handler for managing users
@@ -249,8 +243,6 @@ pub struct AuthResponse {
     pub jwt: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub expires_at: Option<String>,
-    #[serde(flatten)]
-    pub extra: Value,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/tests/bootstrap_tests.rs
+++ b/tests/bootstrap_tests.rs
@@ -51,7 +51,6 @@ fn cluster_bootstrap_config() -> BootstrapConfig {
             username: "admin".to_string(),
             password: "secure123".to_string(),
         }),
-        extra: json!({}),
     }
 }
 
@@ -68,10 +67,6 @@ fn join_node_config() -> BootstrapConfig {
         credentials: Some(CredentialsBootstrap {
             username: "admin".to_string(),
             password: "secure123".to_string(),
-        }),
-        extra: json!({
-            "cluster_host": "10.0.0.1",
-            "cluster_port": 9443
         }),
     }
 }
@@ -326,7 +321,6 @@ async fn test_bootstrap_create_minimal_config() {
             username: "admin".to_string(),
             password: "minimal123".to_string(),
         }),
-        extra: json!({}),
     };
 
     let result = handler.create(config).await;

--- a/tests/cm_settings_tests.rs
+++ b/tests/cm_settings_tests.rs
@@ -151,7 +151,6 @@ async fn test_cm_settings_update_full() {
         slave_ha: Some(true),
         slave_ha_grace_period: Some(600),
         max_simultaneous_backups: Some(5),
-        extra: json!({}),
     };
 
     Mock::given(method("PUT"))
@@ -203,7 +202,6 @@ async fn test_cm_settings_update_partial() {
         slave_ha: None,
         slave_ha_grace_period: None,
         max_simultaneous_backups: Some(2),
-        extra: json!({}),
     };
 
     Mock::given(method("PUT"))
@@ -251,7 +249,6 @@ async fn test_cm_settings_update_minimal() {
         slave_ha: None,
         slave_ha_grace_period: None,
         max_simultaneous_backups: None,
-        extra: json!({}),
     };
 
     Mock::given(method("PUT"))
@@ -295,7 +292,6 @@ async fn test_cm_settings_update_invalid() {
         slave_ha: Some(true),
         slave_ha_grace_period: Some(0),    // Invalid grace period
         max_simultaneous_backups: Some(0), // Invalid backup count
-        extra: json!({}),
     };
 
     Mock::given(method("PUT"))
@@ -388,7 +384,6 @@ async fn test_cm_settings_workflow() {
         slave_ha: Some(true),
         slave_ha_grace_period: Some(300),
         max_simultaneous_backups: Some(3),
-        extra: json!({}),
     };
 
     Mock::given(method("PUT"))

--- a/tests/database_tests.rs
+++ b/tests/database_tests.rs
@@ -507,8 +507,4 @@ async fn test_database_upgrade_redis_version() {
     assert!(result.is_ok());
     let response = result.unwrap();
     assert_eq!(response.action_uid, "591d9dcb-ddd7-48a9-a04d-bd5d4d6834d0");
-    // Verify the flattened extra fields are captured
-    assert_eq!(response.extra["uid"], 1);
-    assert_eq!(response.extra["name"], "test-db");
-    assert_eq!(response.extra["redis_version"], "7.4");
 }

--- a/tests/ldap_mappings_tests.rs
+++ b/tests/ldap_mappings_tests.rs
@@ -90,7 +90,6 @@ fn test_ldap_config_obj() -> LdapConfig {
         authorization_query_suffix: Some("ou=groups,dc=example,dc=com".to_string()),
         bind_dn: Some("cn=service,dc=example,dc=com".to_string()),
         bind_pass: Some("secret".to_string()),
-        extra: json!({}),
     }
 }
 
@@ -456,7 +455,6 @@ async fn test_ldap_update_config_invalid() {
         authorization_query_suffix: None,
         bind_dn: None,
         bind_pass: None,
-        extra: json!({}),
     };
 
     Mock::given(method("PUT"))

--- a/tests/ocsp_tests.rs
+++ b/tests/ocsp_tests.rs
@@ -82,7 +82,6 @@ fn test_ocsp_config_obj() -> OcspConfig {
         query_frequency: Some(3600),
         recovery_frequency: Some(60),
         recovery_max_tries: Some(5),
-        extra: json!({}),
     }
 }
 
@@ -94,7 +93,6 @@ fn test_ocsp_config_minimal() -> OcspConfig {
         query_frequency: None,
         recovery_frequency: None,
         recovery_max_tries: None,
-        extra: json!({}),
     }
 }
 
@@ -229,7 +227,6 @@ async fn test_ocsp_update_config_invalid() {
         query_frequency: None,
         recovery_frequency: None,
         recovery_max_tries: None,
-        extra: json!({}),
     };
 
     Mock::given(method("PUT"))


### PR DESCRIPTION
## Summary

Remove 67 `#[serde(flatten)] pub extra: Value` fields from all response types. This aligns with the approach taken in redis-cloud.

## Rationale

- Cleaner, more explicit API
- Fields should be explicitly typed rather than captured in a catch-all
- If the API adds new fields, we add them explicitly (organically) rather than hiding them in `extra`
- Reduces noise in the codebase

## Changes

- Removes `extra: Value` from 30+ source files
- Updates tests to use typed fields instead of `extra` access
- Removes unused `serde_json::Value` imports

## Test plan

- [x] All tests pass
- [x] Clippy clean

Closes #6