### PR TITLE
feat: add test-support feature for consumer testing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,9 +32,11 @@ chrono = { version = "0.4", features = ["serde"] }
 url = "2.5"
 typed-builder = "0.20"
 tower = { version = "0.5", optional = true }
+wiremock = { version = "0.6", optional = true }
 
 [features]
 tower-integration = ["tower"]
+test-support = ["wiremock"]
 
 [dev-dependencies]
 wiremock = "0.6"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -367,6 +367,10 @@ pub use error::{RestError, Result};
 #[cfg(feature = "tower-integration")]
 pub use client::tower_support;
 
+// Testing utilities for consumers
+#[cfg(feature = "test-support")]
+pub mod testing;
+
 // Database management
 pub use bdb::{
     BdbHandler, CreateDatabaseRequest, CreateDatabaseRequestBuilder, Database, ModuleConfig,

--- a/src/testing/fixtures.rs
+++ b/src/testing/fixtures.rs
@@ -1,0 +1,415 @@
+//! Pre-built fixtures for testing Redis Enterprise API responses
+//!
+//! All fixtures use the builder pattern for customization.
+//!
+//! # Example
+//!
+//! ```
+//! use redis_enterprise::testing::fixtures::{DatabaseFixture, NodeFixture, ClusterFixture};
+//!
+//! // Create a database with defaults
+//! let db = DatabaseFixture::new(1, "my-cache").build();
+//!
+//! // Customize as needed
+//! let db = DatabaseFixture::new(2, "sessions")
+//!     .memory_size(2 * 1024 * 1024 * 1024) // 2GB
+//!     .port(12001)
+//!     .status("creating")
+//!     .build();
+//! ```
+
+use serde_json::{Value, json};
+
+/// Builder for database (BDB) fixtures
+#[derive(Debug, Clone)]
+pub struct DatabaseFixture {
+    uid: u32,
+    name: String,
+    memory_size: u64,
+    port: u16,
+    status: String,
+    db_type: String,
+    replication: bool,
+    persistence: String,
+    shards_count: u32,
+}
+
+impl DatabaseFixture {
+    /// Create a new database fixture with required fields
+    pub fn new(uid: u32, name: impl Into<String>) -> Self {
+        Self {
+            uid,
+            name: name.into(),
+            memory_size: 1024 * 1024 * 1024, // 1GB default
+            port: 12000 + (uid as u16),
+            status: "active".to_string(),
+            db_type: "redis".to_string(),
+            replication: false,
+            persistence: "disabled".to_string(),
+            shards_count: 1,
+        }
+    }
+
+    /// Set memory size in bytes
+    pub fn memory_size(mut self, size: u64) -> Self {
+        self.memory_size = size;
+        self
+    }
+
+    /// Set the database port
+    pub fn port(mut self, port: u16) -> Self {
+        self.port = port;
+        self
+    }
+
+    /// Set the database status
+    pub fn status(mut self, status: impl Into<String>) -> Self {
+        self.status = status.into();
+        self
+    }
+
+    /// Set the database type
+    pub fn db_type(mut self, db_type: impl Into<String>) -> Self {
+        self.db_type = db_type.into();
+        self
+    }
+
+    /// Enable or disable replication
+    pub fn replication(mut self, enabled: bool) -> Self {
+        self.replication = enabled;
+        self
+    }
+
+    /// Set persistence mode
+    pub fn persistence(mut self, mode: impl Into<String>) -> Self {
+        self.persistence = mode.into();
+        self
+    }
+
+    /// Set number of shards
+    pub fn shards_count(mut self, count: u32) -> Self {
+        self.shards_count = count;
+        self
+    }
+
+    /// Build the JSON fixture
+    pub fn build(self) -> Value {
+        json!({
+            "uid": self.uid,
+            "name": self.name,
+            "type": self.db_type,
+            "memory_size": self.memory_size,
+            "port": self.port,
+            "status": self.status,
+            "replication": self.replication,
+            "data_persistence": self.persistence,
+            "shards_count": self.shards_count
+        })
+    }
+}
+
+/// Builder for node fixtures
+#[derive(Debug, Clone)]
+pub struct NodeFixture {
+    uid: u32,
+    addr: String,
+    status: String,
+    total_memory: u64,
+    cores: u32,
+    rack_id: Option<String>,
+    os_version: String,
+}
+
+impl NodeFixture {
+    /// Create a new node fixture with required fields
+    pub fn new(uid: u32, addr: impl Into<String>) -> Self {
+        Self {
+            uid,
+            addr: addr.into(),
+            status: "active".to_string(),
+            total_memory: 8 * 1024 * 1024 * 1024, // 8GB default
+            cores: 4,
+            rack_id: None,
+            os_version: "Ubuntu 22.04".to_string(),
+        }
+    }
+
+    /// Set node status
+    pub fn status(mut self, status: impl Into<String>) -> Self {
+        self.status = status.into();
+        self
+    }
+
+    /// Set total memory in bytes
+    pub fn total_memory(mut self, memory: u64) -> Self {
+        self.total_memory = memory;
+        self
+    }
+
+    /// Set number of CPU cores
+    pub fn cores(mut self, cores: u32) -> Self {
+        self.cores = cores;
+        self
+    }
+
+    /// Set rack ID
+    pub fn rack_id(mut self, rack_id: impl Into<String>) -> Self {
+        self.rack_id = Some(rack_id.into());
+        self
+    }
+
+    /// Set OS version
+    pub fn os_version(mut self, version: impl Into<String>) -> Self {
+        self.os_version = version.into();
+        self
+    }
+
+    /// Build the JSON fixture
+    pub fn build(self) -> Value {
+        let mut obj = json!({
+            "uid": self.uid,
+            "addr": self.addr,
+            "status": self.status,
+            "total_memory": self.total_memory,
+            "cores": self.cores,
+            "os_version": self.os_version
+        });
+
+        if let Some(rack_id) = self.rack_id {
+            obj["rack_id"] = json!(rack_id);
+        }
+
+        obj
+    }
+}
+
+/// Builder for cluster info fixtures
+#[derive(Debug, Clone)]
+pub struct ClusterFixture {
+    name: String,
+    nodes: Vec<u32>,
+}
+
+impl ClusterFixture {
+    /// Create a new cluster fixture
+    pub fn new(name: impl Into<String>) -> Self {
+        Self {
+            name: name.into(),
+            nodes: vec![1],
+        }
+    }
+
+    /// Set the list of node UIDs in the cluster
+    pub fn nodes(mut self, nodes: Vec<u32>) -> Self {
+        self.nodes = nodes;
+        self
+    }
+
+    /// Build the JSON fixture
+    pub fn build(self) -> Value {
+        json!({
+            "name": self.name,
+            "nodes": self.nodes
+        })
+    }
+}
+
+/// Builder for user fixtures
+#[derive(Debug, Clone)]
+pub struct UserFixture {
+    uid: u32,
+    email: String,
+    name: Option<String>,
+    role: String,
+    status: String,
+}
+
+impl UserFixture {
+    /// Create a new user fixture
+    pub fn new(uid: u32, email: impl Into<String>) -> Self {
+        Self {
+            uid,
+            email: email.into(),
+            name: None,
+            role: "admin".to_string(),
+            status: "active".to_string(),
+        }
+    }
+
+    /// Set user's display name
+    pub fn name(mut self, name: impl Into<String>) -> Self {
+        self.name = Some(name.into());
+        self
+    }
+
+    /// Set user's role
+    pub fn role(mut self, role: impl Into<String>) -> Self {
+        self.role = role.into();
+        self
+    }
+
+    /// Set user's status
+    pub fn status(mut self, status: impl Into<String>) -> Self {
+        self.status = status.into();
+        self
+    }
+
+    /// Build the JSON fixture
+    pub fn build(self) -> Value {
+        let mut obj = json!({
+            "uid": self.uid,
+            "email": self.email,
+            "role": self.role,
+            "status": self.status
+        });
+
+        if let Some(name) = self.name {
+            obj["name"] = json!(name);
+        }
+
+        obj
+    }
+}
+
+/// Builder for license fixtures
+#[derive(Debug, Clone)]
+pub struct LicenseFixture {
+    expired: bool,
+    shards_limit: u32,
+    expiration_date: Option<String>,
+}
+
+impl LicenseFixture {
+    /// Create a new license fixture (non-expired by default)
+    pub fn new() -> Self {
+        Self {
+            expired: false,
+            shards_limit: 100,
+            expiration_date: Some("2030-12-31".to_string()),
+        }
+    }
+
+    /// Create an expired license fixture
+    pub fn expired() -> Self {
+        Self {
+            expired: true,
+            shards_limit: 0,
+            expiration_date: Some("2020-01-01".to_string()),
+        }
+    }
+
+    /// Set shards limit
+    pub fn shards_limit(mut self, limit: u32) -> Self {
+        self.shards_limit = limit;
+        self
+    }
+
+    /// Set expiration date
+    pub fn expiration_date(mut self, date: impl Into<String>) -> Self {
+        self.expiration_date = Some(date.into());
+        self
+    }
+
+    /// Build the JSON fixture
+    pub fn build(self) -> Value {
+        let mut obj = json!({
+            "expired": self.expired,
+            "shards_limit": self.shards_limit
+        });
+
+        if let Some(date) = self.expiration_date {
+            obj["expiration_date"] = json!(date);
+        }
+
+        obj
+    }
+}
+
+impl Default for LicenseFixture {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Builder for action response fixtures
+#[derive(Debug, Clone)]
+pub struct ActionFixture {
+    action_uid: String,
+    status: String,
+}
+
+impl ActionFixture {
+    /// Create a new action fixture
+    pub fn new(action_uid: impl Into<String>) -> Self {
+        Self {
+            action_uid: action_uid.into(),
+            status: "completed".to_string(),
+        }
+    }
+
+    /// Set action status
+    pub fn status(mut self, status: impl Into<String>) -> Self {
+        self.status = status.into();
+        self
+    }
+
+    /// Build the JSON fixture
+    pub fn build(self) -> Value {
+        json!({
+            "action_uid": self.action_uid,
+            "status": self.status
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_database_fixture_defaults() {
+        let db = DatabaseFixture::new(1, "test-db").build();
+        assert_eq!(db["uid"], 1);
+        assert_eq!(db["name"], "test-db");
+        assert_eq!(db["status"], "active");
+    }
+
+    #[test]
+    fn test_database_fixture_customized() {
+        let db = DatabaseFixture::new(2, "custom")
+            .memory_size(2 * 1024 * 1024 * 1024)
+            .port(12345)
+            .status("creating")
+            .replication(true)
+            .build();
+
+        assert_eq!(db["uid"], 2);
+        assert_eq!(db["memory_size"], 2 * 1024 * 1024 * 1024u64);
+        assert_eq!(db["port"], 12345);
+        assert_eq!(db["status"], "creating");
+        assert_eq!(db["replication"], true);
+    }
+
+    #[test]
+    fn test_node_fixture() {
+        let node = NodeFixture::new(1, "10.0.0.1")
+            .rack_id("rack-a")
+            .cores(8)
+            .build();
+
+        assert_eq!(node["uid"], 1);
+        assert_eq!(node["addr"], "10.0.0.1");
+        assert_eq!(node["rack_id"], "rack-a");
+        assert_eq!(node["cores"], 8);
+    }
+
+    #[test]
+    fn test_license_fixture() {
+        let license = LicenseFixture::new().shards_limit(50).build();
+        assert_eq!(license["expired"], false);
+        assert_eq!(license["shards_limit"], 50);
+
+        let expired = LicenseFixture::expired().build();
+        assert_eq!(expired["expired"], true);
+    }
+}

--- a/src/testing/mod.rs
+++ b/src/testing/mod.rs
@@ -1,0 +1,106 @@
+//! Testing utilities for Redis Enterprise API client consumers
+//!
+//! This module provides a complete testing infrastructure for applications that use
+//! the redis-enterprise client library. It includes:
+//!
+//! - **Mock server**: A pre-configured wiremock server for simulating the Enterprise API
+//! - **Fixtures**: Builder-pattern fixtures for creating test data
+//! - **Response helpers**: Convenience functions for building common HTTP responses
+//!
+//! # Feature Flag
+//!
+//! This module is only available when the `test-support` feature is enabled:
+//!
+//! ```toml
+//! [dev-dependencies]
+//! redis-enterprise = { version = "0.8", features = ["test-support"] }
+//! ```
+//!
+//! # Quick Start
+//!
+//! ```ignore
+//! use redis_enterprise::testing::{MockEnterpriseServer, fixtures, responses};
+//!
+//! #[tokio::test]
+//! async fn test_my_app() {
+//!     // Start a mock server
+//!     let server = MockEnterpriseServer::start().await;
+//!
+//!     // Set up expected responses using fixtures
+//!     server.mock_databases_list(vec![
+//!         fixtures::DatabaseFixture::new(1, "cache").build(),
+//!         fixtures::DatabaseFixture::new(2, "sessions").memory_size(2_000_000_000).build(),
+//!     ]).await;
+//!
+//!     // Get a client configured to use the mock
+//!     let client = server.client();
+//!
+//!     // Test your application code
+//!     let dbs = client.databases().list().await.unwrap();
+//!     assert_eq!(dbs.len(), 2);
+//! }
+//! ```
+//!
+//! # Testing Error Scenarios
+//!
+//! ```ignore
+//! use redis_enterprise::testing::{MockEnterpriseServer, responses};
+//! use redis_enterprise::RestError;
+//!
+//! #[tokio::test]
+//! async fn test_not_found_error() {
+//!     let server = MockEnterpriseServer::start().await;
+//!
+//!     // Mock a 404 response
+//!     server.mock_path("GET", "/v1/bdbs/999", responses::not_found("Database not found")).await;
+//!
+//!     let client = server.client();
+//!     let result = client.databases().get(999).await;
+//!
+//!     assert!(matches!(result, Err(RestError::NotFound)));
+//! }
+//! ```
+//!
+//! # Custom Mocking
+//!
+//! For advanced scenarios, access the underlying wiremock server directly:
+//!
+//! ```ignore
+//! use redis_enterprise::testing::MockEnterpriseServer;
+//! use wiremock::{Mock, matchers::{method, path, body_json}, ResponseTemplate};
+//!
+//! #[tokio::test]
+//! async fn test_custom_scenario() {
+//!     let server = MockEnterpriseServer::start().await;
+//!
+//!     // Create a custom mock with request body matching
+//!     Mock::given(method("POST"))
+//!         .and(path("/v1/bdbs"))
+//!         .and(body_json(serde_json::json!({
+//!             "name": "new-db",
+//!             "memory_size": 1000000000
+//!         })))
+//!         .respond_with(ResponseTemplate::new(201).set_body_json(serde_json::json!({
+//!             "uid": 1,
+//!             "name": "new-db"
+//!         })))
+//!         .mount(server.inner())
+//!         .await;
+//! }
+//! ```
+
+pub mod fixtures;
+pub mod responses;
+pub mod server;
+
+// Re-export main types for convenience
+pub use fixtures::{
+    ActionFixture, ClusterFixture, DatabaseFixture, LicenseFixture, NodeFixture, UserFixture,
+};
+pub use server::MockEnterpriseServer;
+
+// Re-export wiremock types that consumers will commonly need
+pub use wiremock::{
+    Mock, MockServer, ResponseTemplate,
+    matchers::{body_json, method, path, path_regex},
+};

--- a/src/testing/responses.rs
+++ b/src/testing/responses.rs
@@ -1,0 +1,137 @@
+//! Response helpers for building wiremock responses
+//!
+//! # Example
+//!
+//! ```ignore
+//! use redis_enterprise::testing::responses;
+//! use redis_enterprise::testing::fixtures::DatabaseFixture;
+//!
+//! // Success responses
+//! let ok = responses::success(json!({"status": "ok"}));
+//! let created = responses::created(DatabaseFixture::new(1, "my-db").build());
+//! let no_content = responses::no_content();
+//!
+//! // Error responses
+//! let not_found = responses::not_found("Database not found");
+//! let unauthorized = responses::unauthorized();
+//! let conflict = responses::conflict("Resource already exists");
+//! ```
+
+use serde_json::{Value, json};
+use std::time::Duration;
+use wiremock::ResponseTemplate;
+
+/// Create a 200 OK response with JSON body
+pub fn success(body: impl Into<Value>) -> ResponseTemplate {
+    ResponseTemplate::new(200).set_body_json(body.into())
+}
+
+/// Create a 201 Created response with JSON body
+pub fn created(body: impl Into<Value>) -> ResponseTemplate {
+    ResponseTemplate::new(201).set_body_json(body.into())
+}
+
+/// Create a 204 No Content response
+pub fn no_content() -> ResponseTemplate {
+    ResponseTemplate::new(204)
+}
+
+/// Create a 400 Bad Request response
+pub fn bad_request(message: impl Into<String>) -> ResponseTemplate {
+    let message = message.into();
+    ResponseTemplate::new(400).set_body_json(json!({
+        "error": message,
+        "code": 400
+    }))
+}
+
+/// Create a 401 Unauthorized response
+pub fn unauthorized() -> ResponseTemplate {
+    ResponseTemplate::new(401).set_body_json(json!({
+        "error": "Unauthorized",
+        "code": 401
+    }))
+}
+
+/// Create a 404 Not Found response
+pub fn not_found(message: impl Into<String>) -> ResponseTemplate {
+    let message = message.into();
+    ResponseTemplate::new(404).set_body_json(json!({
+        "error": message,
+        "code": 404
+    }))
+}
+
+/// Create a 409 Conflict response
+pub fn conflict(message: impl Into<String>) -> ResponseTemplate {
+    let message = message.into();
+    ResponseTemplate::new(409).set_body_json(json!({
+        "error": message,
+        "code": 409
+    }))
+}
+
+/// Create a 429 Rate Limited response
+pub fn rate_limited(retry_after: Option<Duration>) -> ResponseTemplate {
+    let mut response = ResponseTemplate::new(429).set_body_json(json!({
+        "error": "Rate limited",
+        "code": 429
+    }));
+
+    if let Some(duration) = retry_after {
+        response = response.insert_header("Retry-After", duration.as_secs().to_string());
+    }
+
+    response
+}
+
+/// Create a 500 Internal Server Error response
+pub fn server_error(message: impl Into<String>) -> ResponseTemplate {
+    let message = message.into();
+    ResponseTemplate::new(500).set_body_json(json!({
+        "error": message,
+        "code": 500
+    }))
+}
+
+/// Create a 503 Service Unavailable (cluster busy) response
+pub fn cluster_busy() -> ResponseTemplate {
+    ResponseTemplate::new(503).set_body_json(json!({
+        "error": "Cluster is busy or unavailable",
+        "code": 503
+    }))
+}
+
+/// Create a custom error response with any status code
+pub fn error(code: u16, message: impl Into<String>) -> ResponseTemplate {
+    let message = message.into();
+    ResponseTemplate::new(code).set_body_json(json!({
+        "error": message,
+        "code": code
+    }))
+}
+
+/// Create a response with a delay (for testing timeouts)
+pub fn delayed(response: ResponseTemplate, delay: Duration) -> ResponseTemplate {
+    response.set_delay(delay)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_success_response() {
+        let _resp = success(json!({"status": "ok"}));
+    }
+
+    #[test]
+    fn test_error_responses() {
+        let _not_found = not_found("Resource not found");
+        let _unauthorized = unauthorized();
+        let _conflict = conflict("Already exists");
+        let _rate_limited = rate_limited(Some(Duration::from_secs(60)));
+        let _server_error = server_error("Internal error");
+        let _cluster_busy = cluster_busy();
+    }
+}

--- a/src/testing/server.rs
+++ b/src/testing/server.rs
@@ -1,0 +1,313 @@
+//! Mock server wrapper for testing Redis Enterprise API clients
+//!
+//! # Example
+//!
+//! ```ignore
+//! use redis_enterprise::testing::MockEnterpriseServer;
+//! use redis_enterprise::testing::fixtures::DatabaseFixture;
+//! use redis_enterprise::testing::responses;
+//!
+//! #[tokio::test]
+//! async fn test_my_app() {
+//!     let server = MockEnterpriseServer::start().await;
+//!
+//!     // Set up mock responses
+//!     server.mock_databases_list(vec![
+//!         DatabaseFixture::new(1, "cache").build(),
+//!         DatabaseFixture::new(2, "sessions").build(),
+//!     ]).await;
+//!
+//!     // Create a client pointing to the mock
+//!     let client = server.client();
+//!
+//!     // Test your application code
+//!     let dbs = client.databases().list().await.unwrap();
+//!     assert_eq!(dbs.len(), 2);
+//! }
+//! ```
+
+use crate::EnterpriseClient;
+use serde_json::Value;
+use wiremock::matchers::{method, path, path_regex};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+/// A wrapper around wiremock's MockServer configured for Redis Enterprise API testing
+pub struct MockEnterpriseServer {
+    server: MockServer,
+}
+
+impl MockEnterpriseServer {
+    /// Start a new mock server
+    pub async fn start() -> Self {
+        Self {
+            server: MockServer::start().await,
+        }
+    }
+
+    /// Get the base URI of the mock server
+    pub fn uri(&self) -> String {
+        self.server.uri()
+    }
+
+    /// Create an EnterpriseClient configured to use this mock server
+    pub fn client(&self) -> EnterpriseClient {
+        EnterpriseClient::builder()
+            .base_url(self.uri())
+            .username("test@example.com")
+            .password("password")
+            .insecure(true)
+            .build()
+            .expect("Failed to build test client")
+    }
+
+    /// Get a reference to the underlying MockServer for custom mocking
+    pub fn inner(&self) -> &MockServer {
+        &self.server
+    }
+
+    // Database mocks
+
+    /// Mock GET /v1/bdbs to return a list of databases
+    pub async fn mock_databases_list(&self, databases: Vec<Value>) {
+        Mock::given(method("GET"))
+            .and(path("/v1/bdbs"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(databases))
+            .mount(&self.server)
+            .await;
+    }
+
+    /// Mock GET /v1/bdbs/{uid} to return a specific database
+    pub async fn mock_database_get(&self, uid: u32, database: Value) {
+        Mock::given(method("GET"))
+            .and(path(format!("/v1/bdbs/{}", uid)))
+            .respond_with(ResponseTemplate::new(200).set_body_json(database))
+            .mount(&self.server)
+            .await;
+    }
+
+    /// Mock POST /v1/bdbs to create a database
+    pub async fn mock_database_create(&self, response: Value) {
+        Mock::given(method("POST"))
+            .and(path("/v1/bdbs"))
+            .respond_with(ResponseTemplate::new(201).set_body_json(response))
+            .mount(&self.server)
+            .await;
+    }
+
+    /// Mock DELETE /v1/bdbs/{uid}
+    pub async fn mock_database_delete(&self, uid: u32) {
+        Mock::given(method("DELETE"))
+            .and(path(format!("/v1/bdbs/{}", uid)))
+            .respond_with(ResponseTemplate::new(204))
+            .mount(&self.server)
+            .await;
+    }
+
+    // Node mocks
+
+    /// Mock GET /v1/nodes to return a list of nodes
+    pub async fn mock_nodes_list(&self, nodes: Vec<Value>) {
+        Mock::given(method("GET"))
+            .and(path("/v1/nodes"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(nodes))
+            .mount(&self.server)
+            .await;
+    }
+
+    /// Mock GET /v1/nodes/{uid} to return a specific node
+    pub async fn mock_node_get(&self, uid: u32, node: Value) {
+        Mock::given(method("GET"))
+            .and(path(format!("/v1/nodes/{}", uid)))
+            .respond_with(ResponseTemplate::new(200).set_body_json(node))
+            .mount(&self.server)
+            .await;
+    }
+
+    // Cluster mocks
+
+    /// Mock GET /v1/cluster to return cluster info
+    pub async fn mock_cluster_info(&self, cluster: Value) {
+        Mock::given(method("GET"))
+            .and(path("/v1/cluster"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(cluster))
+            .mount(&self.server)
+            .await;
+    }
+
+    /// Mock GET /v1/cluster/stats/last to return cluster stats
+    pub async fn mock_cluster_stats(&self, stats: Value) {
+        Mock::given(method("GET"))
+            .and(path("/v1/cluster/stats/last"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(stats))
+            .mount(&self.server)
+            .await;
+    }
+
+    /// Mock GET /v1/license to return license info
+    pub async fn mock_license(&self, license: Value) {
+        Mock::given(method("GET"))
+            .and(path("/v1/license"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(license))
+            .mount(&self.server)
+            .await;
+    }
+
+    // User mocks
+
+    /// Mock GET /v1/users to return a list of users
+    pub async fn mock_users_list(&self, users: Vec<Value>) {
+        Mock::given(method("GET"))
+            .and(path("/v1/users"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(users))
+            .mount(&self.server)
+            .await;
+    }
+
+    /// Mock GET /v1/users/{uid} to return a specific user
+    pub async fn mock_user_get(&self, uid: u32, user: Value) {
+        Mock::given(method("GET"))
+            .and(path(format!("/v1/users/{}", uid)))
+            .respond_with(ResponseTemplate::new(200).set_body_json(user))
+            .mount(&self.server)
+            .await;
+    }
+
+    // Error mocks
+
+    /// Mock any GET request to a path pattern to return 404
+    pub async fn mock_not_found(&self, path_pattern: &str) {
+        Mock::given(method("GET"))
+            .and(path_regex(path_pattern))
+            .respond_with(super::responses::not_found("Resource not found"))
+            .mount(&self.server)
+            .await;
+    }
+
+    /// Mock any request to return 401 Unauthorized
+    pub async fn mock_unauthorized(&self) {
+        Mock::given(method("GET"))
+            .respond_with(super::responses::unauthorized())
+            .mount(&self.server)
+            .await;
+    }
+
+    /// Mock any request to a path to return 500 Server Error
+    pub async fn mock_server_error(&self, path_str: &str, message: &str) {
+        Mock::given(method("GET"))
+            .and(path(path_str))
+            .respond_with(super::responses::server_error(message))
+            .mount(&self.server)
+            .await;
+    }
+
+    // Custom mock support
+
+    /// Mount a custom mock on the server
+    pub async fn mount(&self, mock: Mock) {
+        mock.mount(&self.server).await;
+    }
+
+    /// Mount a custom response template at a specific path
+    pub async fn mock_path(&self, http_method: &str, path_str: &str, response: ResponseTemplate) {
+        Mock::given(method(http_method))
+            .and(path(path_str))
+            .respond_with(response)
+            .mount(&self.server)
+            .await;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::testing::fixtures::{ClusterFixture, DatabaseFixture, NodeFixture};
+
+    #[tokio::test]
+    async fn test_mock_server_starts() {
+        let server = MockEnterpriseServer::start().await;
+        assert!(server.uri().starts_with("http://"));
+    }
+
+    #[tokio::test]
+    async fn test_mock_databases_list() {
+        let server = MockEnterpriseServer::start().await;
+        server
+            .mock_databases_list(vec![
+                DatabaseFixture::new(1, "test-db").build(),
+                DatabaseFixture::new(2, "other-db").build(),
+            ])
+            .await;
+
+        let client = server.client();
+        let dbs = client.databases().list().await.unwrap();
+        assert_eq!(dbs.len(), 2);
+        assert_eq!(dbs[0].name, "test-db");
+        assert_eq!(dbs[1].name, "other-db");
+    }
+
+    #[tokio::test]
+    async fn test_mock_database_get() {
+        let server = MockEnterpriseServer::start().await;
+        server
+            .mock_database_get(
+                1,
+                DatabaseFixture::new(1, "my-cache")
+                    .memory_size(2 * 1024 * 1024 * 1024)
+                    .build(),
+            )
+            .await;
+
+        let client = server.client();
+        let db = client.databases().get(1).await.unwrap();
+        assert_eq!(db.name, "my-cache");
+        assert_eq!(db.memory_size, Some(2 * 1024 * 1024 * 1024));
+    }
+
+    #[tokio::test]
+    async fn test_mock_nodes_list() {
+        let server = MockEnterpriseServer::start().await;
+        server
+            .mock_nodes_list(vec![
+                NodeFixture::new(1, "10.0.0.1").build(),
+                NodeFixture::new(2, "10.0.0.2").cores(8).build(),
+            ])
+            .await;
+
+        let client = server.client();
+        let nodes = client.nodes().list().await.unwrap();
+        assert_eq!(nodes.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn test_mock_cluster_info() {
+        let server = MockEnterpriseServer::start().await;
+        server
+            .mock_cluster_info(
+                ClusterFixture::new("test-cluster")
+                    .nodes(vec![1, 2, 3])
+                    .build(),
+            )
+            .await;
+
+        let client = server.client();
+        let info = client.cluster().info().await.unwrap();
+        assert_eq!(info.name, "test-cluster");
+    }
+
+    #[tokio::test]
+    async fn test_custom_mock() {
+        use wiremock::ResponseTemplate;
+        use wiremock::matchers::{method, path};
+
+        let server = MockEnterpriseServer::start().await;
+
+        // Use the inner MockServer for custom mocking
+        Mock::given(method("GET"))
+            .and(path("/v1/custom"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "custom": "response"
+            })))
+            .mount(server.inner())
+            .await;
+    }
+}


### PR DESCRIPTION
## Summary

- Add `test-support` feature that exposes mocking infrastructure for consumers
- MockEnterpriseServer: wiremock wrapper with pre-built mocks for common API endpoints
- Builder-pattern fixtures for Database, Node, Cluster, User, License, and Action
- Response helpers for success, error, rate-limited, and delayed responses
- Re-exports common wiremock types for custom mocking scenarios

## Usage

```toml
[dev-dependencies]
redis-enterprise = { version = "0.8", features = ["test-support"] }
```

```rust
use redis_enterprise::testing::{MockEnterpriseServer, fixtures, responses};

#[tokio::test]
async fn test_my_app() {
    let server = MockEnterpriseServer::start().await;
    
    server.mock_databases_list(vec![
        fixtures::DatabaseFixture::new(1, "cache").build(),
        fixtures::DatabaseFixture::new(2, "sessions").memory_size(2_000_000_000).build(),
    ]).await;

    let client = server.client();
    let dbs = client.databases().list().await.unwrap();
    assert_eq!(dbs.len(), 2);
}
```

## Test plan

- [x] All existing tests pass
- [x] New testing module compiles with feature enabled
- [x] MockEnterpriseServer tests pass
- [x] Fixture builder tests pass
- [x] Response helper tests pass

Closes #16