### PR TITLE
chore: release v0.8.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.1](https://github.com/redis-developer/redis-enterprise-rs/compare/v0.8.0...v0.8.1) - 2026-01-31
+
+### Added
+
+- add test-support feature for consumer testing ([#17](https://github.com/redis-developer/redis-enterprise-rs/pull/17))
+
+### Fixed
+
+- add AlertFixture and alerts mocking support ([#19](https://github.com/redis-developer/redis-enterprise-rs/pull/19))
+
 ## [0.8.0](https://github.com/redis-developer/redis-enterprise-rs/compare/v0.7.5...v0.8.0) - 2026-01-30
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1049,7 +1049,7 @@ dependencies = [
 
 [[package]]
 name = "redis-enterprise"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "redis-enterprise"
-version = "0.8.0"
+version = "0.8.1"
 edition = "2024"
 rust-version = "1.85"
 authors = ["Josh Rotenberg <joshrotenberg@gmail.com>"]


### PR DESCRIPTION



## 🤖 New release

* `redis-enterprise`: 0.8.0 -> 0.8.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.8.1](https://github.com/redis-developer/redis-enterprise-rs/compare/v0.8.0...v0.8.1) - 2026-01-31

### Added

- add test-support feature for consumer testing ([#17](https://github.com/redis-developer/redis-enterprise-rs/pull/17))

### Fixed

- add AlertFixture and alerts mocking support ([#19](https://github.com/redis-developer/redis-enterprise-rs/pull/19))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).