### PR TITLE
fix: add AlertFixture and alerts mocking support

### DIFF
--- a/src/testing/mod.rs
+++ b/src/testing/mod.rs
@@ -95,7 +95,8 @@ pub mod server;
 
 // Re-export main types for convenience
 pub use fixtures::{
-    ActionFixture, ClusterFixture, DatabaseFixture, LicenseFixture, NodeFixture, UserFixture,
+    ActionFixture, AlertFixture, ClusterFixture, DatabaseFixture, LicenseFixture, NodeFixture,
+    UserFixture,
 };
 pub use server::MockEnterpriseServer;
 


### PR DESCRIPTION
## Summary

- Add `AlertFixture` builder with all required fields (`uid`, `name`, `severity`, `state`) and optional fields (`entity_type`, `entity_name`, `entity_uid`, `description`, `threshold`, `change_time`)
- Add alerts mocking methods to `MockEnterpriseServer`:
  - `mock_alerts_list()` - mock GET /v1/alerts
  - `mock_alert_get()` - mock GET /v1/alerts/{uid}
  - `mock_database_alerts()` - mock GET /v1/bdbs/{uid}/alerts
  - `mock_node_alerts()` - mock GET /v1/nodes/{uid}/alerts
  - `mock_cluster_alerts()` - mock GET /v1/cluster/alerts
- Add integration tests that verify mock helpers work with actual handlers

## Test plan

- [x] All existing tests pass
- [x] New AlertFixture unit tests
- [x] Integration tests for alerts mocking with handlers