### PR TITLE
chore: update bytes to 1.11.1 (RUSTSEC-2026-0007)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -173,9 +173,9 @@ checksum = "5dd9dc738b7a8311c7ade152424974d8115f2cdad61e8dab8dac9f2362298510"
 
 [[package]]
 name = "bytes"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b35204fbdc0b3f4446b89fc1ac2cf84a8a68971995d0bf2e925ec7cd960f9cb3"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cc"


### PR DESCRIPTION
## Summary

Fix integer overflow vulnerability in `BytesMut::reserve`.

## Advisory

- **ID**: RUSTSEC-2026-0007
- **Affected**: bytes < 1.11.1
- **Fixed**: bytes >= 1.11.1

https://rustsec.org/advisories/RUSTSEC-2026-0007