### PR TITLE
chore: release v0.8.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.2](https://github.com/redis-developer/redis-enterprise-rs/compare/v0.8.1...v0.8.2) - 2026-02-03
+
+### Added
+
+- add custom CA certificate support and upgrade reqwest to 0.13 ([#21](https://github.com/redis-developer/redis-enterprise-rs/pull/21))
+
+### Other
+
+- add CA cert tests and client_builder() for test support ([#24](https://github.com/redis-developer/redis-enterprise-rs/pull/24))
+- update bytes to 1.11.1 (RUSTSEC-2026-0007) ([#22](https://github.com/redis-developer/redis-enterprise-rs/pull/22))
+
 ## [0.8.1](https://github.com/redis-developer/redis-enterprise-rs/compare/v0.8.0...v0.8.1) - 2026-01-31
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1158,7 +1158,7 @@ dependencies = [
 
 [[package]]
 name = "redis-enterprise"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "redis-enterprise"
-version = "0.8.1"
+version = "0.8.2"
 edition = "2024"
 rust-version = "1.85"
 authors = ["Josh Rotenberg <joshrotenberg@gmail.com>"]


### PR DESCRIPTION



## 🤖 New release

* `redis-enterprise`: 0.8.1 -> 0.8.2 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.8.2](https://github.com/redis-developer/redis-enterprise-rs/compare/v0.8.1...v0.8.2) - 2026-02-03

### Added

- add custom CA certificate support and upgrade reqwest to 0.13 ([#21](https://github.com/redis-developer/redis-enterprise-rs/pull/21))

### Other

- add CA cert tests and client_builder() for test support ([#24](https://github.com/redis-developer/redis-enterprise-rs/pull/24))
- update bytes to 1.11.1 (RUSTSEC-2026-0007) ([#22](https://github.com/redis-developer/redis-enterprise-rs/pull/22))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).