### PR TITLE
test: add CA cert tests and client_builder() for test support

### DIFF
--- a/src/testing/server.rs
+++ b/src/testing/server.rs
@@ -51,13 +51,34 @@ impl MockEnterpriseServer {
 
     /// Create an EnterpriseClient configured to use this mock server
     pub fn client(&self) -> EnterpriseClient {
+        self.client_builder()
+            .build()
+            .expect("Failed to build test client")
+    }
+
+    /// Get a pre-configured client builder for this mock server
+    ///
+    /// Use this when you need to customize the client configuration,
+    /// for example to test CA certificate handling or custom timeouts.
+    ///
+    /// # Example
+    ///
+    /// ```ignore
+    /// let server = MockEnterpriseServer::start().await;
+    ///
+    /// // Customize the client
+    /// let client = server.client_builder()
+    ///     .timeout(std::time::Duration::from_secs(5))
+    ///     .user_agent("my-app/1.0")
+    ///     .build()
+    ///     .unwrap();
+    /// ```
+    pub fn client_builder(&self) -> crate::EnterpriseClientBuilder {
         EnterpriseClient::builder()
             .base_url(self.uri())
             .username("test@example.com")
             .password("password")
             .insecure(true)
-            .build()
-            .expect("Failed to build test client")
     }
 
     /// Get a reference to the underlying MockServer for custom mocking


### PR DESCRIPTION
## Summary

Add tests and test support for the CA certificate feature.

## Changes

### Tests (`lib_tests.rs`)
- `test_ca_cert_builder_path_nonexistent`: Verifies error handling when CA cert path doesn't exist
- `test_ca_cert_from_env`: Verifies `from_env()` exists and handles missing env vars

### Test Support (`testing/server.rs`)
- Add `client_builder()` method to `MockEnterpriseServer`
- Allows consumers to customize client configuration in tests (e.g., timeouts, user agents)

## Usage

```rust
// Before: only default client
let client = server.client();

// After: customize as needed
let client = server.client_builder()
    .timeout(Duration::from_secs(5))
    .user_agent("my-app/1.0")
    .build()
    .unwrap();
```

## Test plan

- [x] `cargo test --lib` passes (18 tests)
- [x] `cargo clippy --all-features` passes