### PR TITLE
feat: add TypedBuilder to bootstrap types and error helper

### DIFF
--- a/src/bdb.rs
+++ b/src/bdb.rs
@@ -136,38 +136,64 @@ pub struct ModuleUpgrade {
 }
 
 /// Request for database upgrade operation
-#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+///
+/// # Examples
+///
+/// ```rust,no_run
+/// use redis_enterprise::bdb::DatabaseUpgradeRequest;
+///
+/// // Upgrade to latest Redis version with role preservation
+/// let request = DatabaseUpgradeRequest::builder()
+///     .preserve_roles(true)
+///     .build();
+///
+/// // Upgrade to specific version
+/// let request = DatabaseUpgradeRequest::builder()
+///     .redis_version("7.4.2")
+///     .preserve_roles(true)
+///     .parallel_shards_upgrade(2)
+///     .build();
+/// ```
+#[derive(Debug, Clone, Serialize, Deserialize, Default, TypedBuilder)]
 pub struct DatabaseUpgradeRequest {
     /// Target Redis version (optional, defaults to latest)
     #[serde(skip_serializing_if = "Option::is_none")]
+    #[builder(default, setter(into, strip_option))]
     pub redis_version: Option<String>,
 
     /// Preserve master/replica roles (requires extra failover)
     #[serde(skip_serializing_if = "Option::is_none")]
+    #[builder(default, setter(strip_option))]
     pub preserve_roles: Option<bool>,
 
     /// Restart shards even if no version change
     #[serde(skip_serializing_if = "Option::is_none")]
+    #[builder(default, setter(strip_option))]
     pub force_restart: Option<bool>,
 
     /// Allow data loss in non-replicated, non-persistent databases
     #[serde(skip_serializing_if = "Option::is_none")]
+    #[builder(default, setter(strip_option))]
     pub may_discard_data: Option<bool>,
 
     /// Force data discard even if replicated/persistent
     #[serde(skip_serializing_if = "Option::is_none")]
+    #[builder(default, setter(strip_option))]
     pub force_discard: Option<bool>,
 
     /// Keep current CRDT protocol version
     #[serde(skip_serializing_if = "Option::is_none")]
+    #[builder(default, setter(strip_option))]
     pub keep_crdt_protocol_version: Option<bool>,
 
     /// Maximum parallel shard upgrades (default: all shards)
     #[serde(skip_serializing_if = "Option::is_none")]
+    #[builder(default, setter(strip_option))]
     pub parallel_shards_upgrade: Option<u32>,
 
     /// Modules to upgrade alongside Redis
     #[serde(skip_serializing_if = "Option::is_none")]
+    #[builder(default, setter(strip_option))]
     pub modules: Option<Vec<ModuleUpgrade>>,
 }
 

--- a/src/bootstrap.rs
+++ b/src/bootstrap.rs
@@ -9,61 +9,92 @@ use crate::client::RestClient;
 use crate::error::Result;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
+use typed_builder::TypedBuilder;
 
 /// Bootstrap configuration for cluster initialization
-#[derive(Debug, Clone, Serialize, Deserialize)]
+///
+/// # Examples
+///
+/// ```rust,no_run
+/// use redis_enterprise::{BootstrapConfig, ClusterBootstrap, CredentialsBootstrap};
+///
+/// let config = BootstrapConfig::builder()
+///     .action("create_cluster")
+///     .cluster(ClusterBootstrap::builder()
+///         .name("my-cluster.local")
+///         .rack_aware(true)
+///         .build())
+///     .credentials(CredentialsBootstrap::builder()
+///         .username("admin@example.com")
+///         .password("secure-password")
+///         .build())
+///     .build();
+/// ```
+#[derive(Debug, Clone, Serialize, Deserialize, TypedBuilder)]
 pub struct BootstrapConfig {
     /// Action to perform (e.g., 'create', 'join', 'recover_cluster')
+    #[builder(setter(into))]
     pub action: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
     /// Cluster configuration for initialization
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[builder(default, setter(strip_option))]
     pub cluster: Option<ClusterBootstrap>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     /// Node configuration for bootstrap
-    pub node: Option<NodeBootstrap>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    #[builder(default, setter(strip_option))]
+    pub node: Option<NodeBootstrap>,
     /// Admin credentials for cluster access
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[builder(default, setter(strip_option))]
     pub credentials: Option<CredentialsBootstrap>,
 }
 
 /// Cluster bootstrap configuration
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, TypedBuilder)]
 pub struct ClusterBootstrap {
     /// Cluster name for identification
+    #[builder(setter(into))]
     pub name: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
     /// DNS suffixes for cluster FQDN resolution
-    pub dns_suffixes: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    #[builder(default, setter(strip_option))]
+    pub dns_suffixes: Option<Vec<String>>,
     /// Enable rack-aware placement for high availability
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[builder(default, setter(strip_option))]
     pub rack_aware: Option<bool>,
 }
 
 /// Node bootstrap configuration
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, TypedBuilder)]
 pub struct NodeBootstrap {
-    #[serde(skip_serializing_if = "Option::is_none")]
     /// Storage paths configuration for the node
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[builder(default, setter(strip_option))]
     pub paths: Option<NodePaths>,
 }
 
 /// Node paths configuration
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, TypedBuilder)]
 pub struct NodePaths {
-    #[serde(skip_serializing_if = "Option::is_none")]
     /// Path for persistent storage (databases, configuration, logs)
-    pub persistent_path: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    #[builder(default, setter(into, strip_option))]
+    pub persistent_path: Option<String>,
     /// Path for ephemeral storage (temporary files, caches)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[builder(default, setter(into, strip_option))]
     pub ephemeral_path: Option<String>,
 }
 
 /// Credentials bootstrap configuration
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, TypedBuilder)]
 pub struct CredentialsBootstrap {
     /// Admin username for cluster management
+    #[builder(setter(into))]
     pub username: String,
     /// Admin password for authentication
+    #[builder(setter(into))]
     pub password: String,
 }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -120,6 +120,12 @@ impl RestError {
             || self.is_cluster_busy()
             || self.is_server_error()
     }
+
+    /// Check if this is a bad request / validation error
+    pub fn is_bad_request(&self) -> bool {
+        matches!(self, RestError::ValidationError(_))
+            || matches!(self, RestError::ApiError { code, .. } if *code == 400)
+    }
 }
 
 pub type Result<T> = std::result::Result<T, RestError>;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -373,7 +373,8 @@ pub mod testing;
 
 // Database management
 pub use bdb::{
-    BdbHandler, CreateDatabaseRequest, CreateDatabaseRequestBuilder, Database, ModuleConfig,
+    BdbHandler, CreateDatabaseRequest, CreateDatabaseRequestBuilder, Database,
+    DatabaseUpgradeRequest, ModuleConfig,
 };
 
 // Database groups


### PR DESCRIPTION
## Summary

- Add `TypedBuilder` derive to `DatabaseUpgradeRequest` for consistent builder pattern usage
- Add `TypedBuilder` derive to all bootstrap types (`BootstrapConfig`, `ClusterBootstrap`, `NodeBootstrap`, `NodePaths`, `CredentialsBootstrap`)
- Add `is_bad_request()` error helper method to `RestError` for checking validation/400 errors
- Export `DatabaseUpgradeRequest` from `lib.rs` for public API access

This is part of the redisctl core architecture spike to harmonize patterns across the redis-cloud and redis-enterprise crates.

## Test plan

- [x] All existing tests pass (`cargo test --lib --all-features`)
- [x] Clippy passes with no warnings
- [x] Format check passes