### PR TITLE
chore: release v0.8.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.3](https://github.com/redis-developer/redis-enterprise-rs/compare/v0.8.2...v0.8.3) - 2026-02-04
+
+### Added
+
+- add TypedBuilder to bootstrap types and error helper ([#26](https://github.com/redis-developer/redis-enterprise-rs/pull/26))
+
 ## [0.8.2](https://github.com/redis-developer/redis-enterprise-rs/compare/v0.8.1...v0.8.2) - 2026-02-03
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1158,7 +1158,7 @@ dependencies = [
 
 [[package]]
 name = "redis-enterprise"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "redis-enterprise"
-version = "0.8.2"
+version = "0.8.3"
 edition = "2024"
 rust-version = "1.85"
 authors = ["Josh Rotenberg <joshrotenberg@gmail.com>"]


### PR DESCRIPTION



## 🤖 New release

* `redis-enterprise`: 0.8.2 -> 0.8.3 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.8.3](https://github.com/redis-developer/redis-enterprise-rs/compare/v0.8.2...v0.8.3) - 2026-02-04

### Added

- add TypedBuilder to bootstrap types and error helper ([#26](https://github.com/redis-developer/redis-enterprise-rs/pull/26))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).