### PR TITLE
chore: release v0.8.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.4](https://github.com/redis-developer/redis-enterprise-rs/compare/v0.8.3...v0.8.4) - 2026-02-05
+
+### Other
+
+- update rust-version to 1.89 and author email ([#29](https://github.com/redis-developer/redis-enterprise-rs/pull/29))
+
 ## [0.8.3](https://github.com/redis-developer/redis-enterprise-rs/compare/v0.8.2...v0.8.3) - 2026-02-04
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1158,7 +1158,7 @@ dependencies = [
 
 [[package]]
 name = "redis-enterprise"
-version = "0.8.3"
+version = "0.8.4"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "redis-enterprise"
-version = "0.8.3"
+version = "0.8.4"
 edition = "2024"
 rust-version = "1.89"
 authors = ["Josh Rotenberg <josh.rotenberg@redis.com>"]


### PR DESCRIPTION



## 🤖 New release

* `redis-enterprise`: 0.8.3 -> 0.8.4 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.8.4](https://github.com/redis-developer/redis-enterprise-rs/compare/v0.8.3...v0.8.4) - 2026-02-05

### Other

- update rust-version to 1.89 and author email ([#29](https://github.com/redis-developer/redis-enterprise-rs/pull/29))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).