### PR TITLE
fix: sync Python package version with Rust crate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,17 @@ lcov.info
 # Backup files
 *.bak
 *.backup
+
+# Python
+__pycache__/
+*.py[cod]
+*$py.class
+*.so
+.Python
+build/
+dist/
+*.egg-info/
+.eggs/
+*.whl
+.venv/
+venv/

--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "redis-enterprise-py"
-version = "0.1.0"
+version = "0.8.3"
 edition = "2024"
 rust-version = "1.89"
 authors = ["Josh Rotenberg <josh.rotenberg@redis.com>"]

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,12 +4,12 @@ build-backend = "maturin"
 
 [project]
 name = "redis-enterprise"
-version = "0.1.0"
+dynamic = ["version"]
 description = "Python bindings for Redis Enterprise REST API client"
 readme = { file = "../README.md", content-type = "text/markdown" }
 license = { text = "MIT OR Apache-2.0" }
 authors = [
-    { name = "Josh Rotenberg", email = "joshrotenberg@gmail.com" }
+    { name = "Josh Rotenberg", email = "josh.rotenberg@redis.com" }
 ]
 keywords = ["redis", "enterprise", "api", "rest", "client"]
 classifiers = [


### PR DESCRIPTION
## Summary

Fix Python package publishing - version was stuck at 0.1.0 while Rust crate is 0.8.3.

## Changes

- Update `python/Cargo.toml` version to 0.8.3 (match main crate)
- Use `dynamic = ["version"]` in pyproject.toml (maturin reads from Cargo.toml)
- Update author email to josh.rotenberg@redis.com
- Add Python patterns to .gitignore

## Note

After merging, future releases will need to keep `python/Cargo.toml` version in sync with the main crate. Consider adding this to release-plz config or using a pre-release script.