### PR TITLE
chore: release v0.8.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.5](https://github.com/redis-developer/redis-enterprise-rs/compare/v0.8.4...v0.8.5) - 2026-02-10
+
+### Fixed
+
+- sync Python package version with Rust crate ([#31](https://github.com/redis-developer/redis-enterprise-rs/pull/31))
+
+### Other
+
+- Fix module platforms deserialization - use HashMap instead of Vec ([#33](https://github.com/redis-developer/redis-enterprise-rs/pull/33))
+
 ## [0.8.4](https://github.com/redis-developer/redis-enterprise-rs/compare/v0.8.3...v0.8.4) - 2026-02-05
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1158,7 +1158,7 @@ dependencies = [
 
 [[package]]
 name = "redis-enterprise"
-version = "0.8.4"
+version = "0.8.5"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "redis-enterprise"
-version = "0.8.4"
+version = "0.8.5"
 edition = "2024"
 rust-version = "1.89"
 authors = ["Josh Rotenberg <josh.rotenberg@redis.com>"]


### PR DESCRIPTION



## 🤖 New release

* `redis-enterprise`: 0.8.4 -> 0.8.5 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.8.5](https://github.com/redis-developer/redis-enterprise-rs/compare/v0.8.4...v0.8.5) - 2026-02-10

### Fixed

- sync Python package version with Rust crate ([#31](https://github.com/redis-developer/redis-enterprise-rs/pull/31))

### Other

- Fix module platforms deserialization - use HashMap instead of Vec ([#33](https://github.com/redis-developer/redis-enterprise-rs/pull/33))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).