### PR TITLE
Fix module platforms deserialization - use HashMap instead of Vec

### DIFF
--- a/src/modules.rs
+++ b/src/modules.rs
@@ -9,6 +9,18 @@ use crate::client::RestClient;
 use crate::error::Result;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
+use std::collections::HashMap;
+
+/// Platform-specific information for a module
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PlatformInfo {
+    /// Platform dependencies (typically an empty object)
+    #[serde(default)]
+    pub dependencies: Value,
+
+    /// SHA256 checksum of the module binary for this platform
+    pub sha256: Option<String>,
+}
 
 /// Module information
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -52,8 +64,10 @@ pub struct Module {
     /// Minimum Redis Enterprise version required for this module
     pub min_redis_pack_version: Option<String>,
 
-    /// List of platforms this module supports (e.g., 'linux-x64', 'linux-arm64')
-    pub platforms: Option<Vec<String>>,
+    /// Platform-specific information for this module
+    /// Maps platform names (e.g., 'rhel9/x86_64', 'rhel8/x86_64') to platform details
+    #[serde(default)]
+    pub platforms: Option<HashMap<String, PlatformInfo>>,
 
     /// SHA256 checksum of the module binary for verification
     pub sha256: Option<String>,

--- a/tests/module_tests.rs
+++ b/tests/module_tests.rs
@@ -191,9 +191,7 @@ async fn test_module_list_with_platforms_map() {
     Mock::given(method("GET"))
         .and(path("/v1/modules"))
         .and(basic_auth("admin", "password"))
-        .respond_with(success_response(json!([
-            test_module_with_platforms()
-        ])))
+        .respond_with(success_response(json!([test_module_with_platforms()])))
         .mount(&mock_server)
         .await;
 
@@ -208,7 +206,11 @@ async fn test_module_list_with_platforms_map() {
     let result = handler.list().await;
 
     // This should succeed after the fix
-    assert!(result.is_ok(), "Failed to deserialize module with platforms map: {:?}", result.err());
+    assert!(
+        result.is_ok(),
+        "Failed to deserialize module with platforms map: {:?}",
+        result.err()
+    );
     let modules = result.unwrap();
     assert_eq!(modules.len(), 1);
 
@@ -217,7 +219,10 @@ async fn test_module_list_with_platforms_map() {
     assert_eq!(module.module_name, Some("search".to_string()));
 
     // After the fix, platforms should be accessible as a HashMap
-    assert!(module.platforms.is_some(), "Platforms field should be present");
+    assert!(
+        module.platforms.is_some(),
+        "Platforms field should be present"
+    );
 }
 
 /// Test getting a single module with platforms field
@@ -243,9 +248,16 @@ async fn test_module_get_with_platforms_map() {
     let result = handler.get("2").await;
 
     // This should succeed after the fix
-    assert!(result.is_ok(), "Failed to deserialize module with platforms map: {:?}", result.err());
+    assert!(
+        result.is_ok(),
+        "Failed to deserialize module with platforms map: {:?}",
+        result.err()
+    );
     let module = result.unwrap();
     assert_eq!(module.uid, "2");
     assert_eq!(module.module_name, Some("search".to_string()));
-    assert!(module.platforms.is_some(), "Platforms field should be present");
+    assert!(
+        module.platforms.is_some(),
+        "Platforms field should be present"
+    );
 }

--- a/tests/module_tests.rs
+++ b/tests/module_tests.rs
@@ -28,6 +28,37 @@ fn test_module() -> serde_json::Value {
     })
 }
 
+/// Test module with platforms field as returned by the actual API
+/// The API returns platforms as a map/object, not an array
+fn test_module_with_platforms() -> serde_json::Value {
+    json!({
+        "uid": "2",
+        "module_name": "search",
+        "semantic_version": "2.10.15",
+        "version": 21015,
+        "author": "RedisLabs",
+        "description": "High performance search index on top of Redis",
+        "homepage": "http://redisearch.io",
+        "license": "Redis Source Available License 2.0",
+        "command_line_args": "",
+        "capabilities": ["search", "index"],
+        "min_redis_version": "7.4",
+        "compatible_redis_version": "7.4",
+        "display_name": "RediSearch 2",
+        "is_bundled": true,
+        "platforms": {
+            "rhel9/x86_64": {
+                "dependencies": {},
+                "sha256": "6bad5fdb464af8ecdf98b63dc26d65e08774826fbc11b0b5a8da363cb97fbd8c"
+            },
+            "rhel8/x86_64": {
+                "dependencies": {},
+                "sha256": "abc123def456789"
+            }
+        }
+    })
+}
+
 #[tokio::test]
 async fn test_module_list() {
     let mock_server = MockServer::start().await;
@@ -149,4 +180,72 @@ async fn test_module_delete() {
     let result = handler.delete("1").await;
 
     assert!(result.is_ok());
+}
+
+/// Test that demonstrates the bug: platforms field is returned as a map by the API
+/// but the Module struct expects it as a Vec<String>
+#[tokio::test]
+async fn test_module_list_with_platforms_map() {
+    let mock_server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/v1/modules"))
+        .and(basic_auth("admin", "password"))
+        .respond_with(success_response(json!([
+            test_module_with_platforms()
+        ])))
+        .mount(&mock_server)
+        .await;
+
+    let client = EnterpriseClient::builder()
+        .base_url(mock_server.uri())
+        .username("admin")
+        .password("password")
+        .build()
+        .unwrap();
+
+    let handler = ModuleHandler::new(client);
+    let result = handler.list().await;
+
+    // This should succeed after the fix
+    assert!(result.is_ok(), "Failed to deserialize module with platforms map: {:?}", result.err());
+    let modules = result.unwrap();
+    assert_eq!(modules.len(), 1);
+
+    let module = &modules[0];
+    assert_eq!(module.uid, "2");
+    assert_eq!(module.module_name, Some("search".to_string()));
+
+    // After the fix, platforms should be accessible as a HashMap
+    assert!(module.platforms.is_some(), "Platforms field should be present");
+}
+
+/// Test getting a single module with platforms field
+#[tokio::test]
+async fn test_module_get_with_platforms_map() {
+    let mock_server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/v1/modules/2"))
+        .and(basic_auth("admin", "password"))
+        .respond_with(success_response(test_module_with_platforms()))
+        .mount(&mock_server)
+        .await;
+
+    let client = EnterpriseClient::builder()
+        .base_url(mock_server.uri())
+        .username("admin")
+        .password("password")
+        .build()
+        .unwrap();
+
+    let handler = ModuleHandler::new(client);
+    let result = handler.get("2").await;
+
+    // This should succeed after the fix
+    assert!(result.is_ok(), "Failed to deserialize module with platforms map: {:?}", result.err());
+    let module = result.unwrap();
+    assert_eq!(module.uid, "2");
+    assert_eq!(module.module_name, Some("search".to_string()));
+    assert!(module.platforms.is_some(), "Platforms field should be present");
 }


### PR DESCRIPTION
## Problem

The Redis Enterprise API returns the `platforms` field as a JSON object (map) where keys are platform names (e.g., `rhel9/x86_64`) and values are objects containing `dependencies` and `sha256` fields.

Example from actual API response:
```json
{
  "module_name": "search",
  "semantic_version": "2.10.15",
  "platforms": {
    "rhel9/x86_64": {
      "dependencies": {},
      "sha256": "6bad5fdb464af8ecdf98b63dc26d65e08774826fbc11b0b5a8da363cb97fbd8c"
    }
  }
}
```

Previously, the `Module` struct expected `platforms` to be a `Vec<String>`, which caused deserialization errors:

```
Error: API error: Parse error: Failed to deserialize field '[0].platforms': 
invalid type: map, expected a sequence at line 1 column 817
```

This error occurred when using `redisctl enterprise database create --module <name>` command.

## Solution

- Added `PlatformInfo` struct to represent platform-specific data with `dependencies` and `sha256` fields
- Changed `Module.platforms` from `Option<Vec<String>>` to `Option<HashMap<String, PlatformInfo>>`
- Added `#[serde(default)]` attribute to handle cases where platforms field is missing or null
- Added comprehensive tests using real API response format from the issue

## Testing

### Unit Tests
- Added `test_module_list_with_platforms_map()` - tests deserializing a list of modules with platforms as a map
- Added `test_module_get_with_platforms_map()` - tests deserializing a single module with platforms as a map
- All 355 tests pass

### Integration Tests
Tested with real Redis Enterprise cluster:
- ✅ Module list command successfully deserializes platforms field
- ✅ Database create command successfully reads module list (no more deserialization errors)

## Breaking Changes

This changes the type of `Module.platforms` from `Option<Vec<String>>` to `Option<HashMap<String, PlatformInfo>>`. 

Any code that accesses the `platforms` field will need to be updated. However, since the previous implementation would fail to deserialize real API responses, this is unlikely to affect working code.

## Fixes

Fixes redis-developer/redisctl#660

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author