### PR TITLE
fix: handle empty 200 response from PUT /v1/license

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -489,6 +489,34 @@ impl EnterpriseClient {
         }
     }
 
+    /// PUT request for actions that return no content (or may return an empty body)
+    pub async fn put_action<B: Serialize>(&self, path: &str, body: &B) -> Result<()> {
+        let url = self.normalize_url(path);
+        debug!("PUT {}", url);
+        trace!("Request body: {:?}", serde_json::to_value(body).ok());
+
+        let response = self
+            .client
+            .put(&url)
+            .basic_auth(&self.username, Some(&self.password))
+            .json(body)
+            .send()
+            .await
+            .map_err(|e| self.map_reqwest_error(e, &url))?;
+
+        trace!("Response status: {}", response.status());
+        if response.status().is_success() {
+            Ok(())
+        } else {
+            let status = response.status();
+            let text = response.text().await.unwrap_or_default();
+            Err(RestError::ApiError {
+                code: status.as_u16(),
+                message: text,
+            })
+        }
+    }
+
     /// POST request with multipart/form-data for file uploads
     pub async fn post_multipart<T: DeserializeOwned>(
         &self,

--- a/src/license.rs
+++ b/src/license.rs
@@ -116,8 +116,13 @@ impl LicenseHandler {
     }
 
     /// Update license
+    ///
+    /// The Redis Enterprise API may return 200 with an empty body for this
+    /// endpoint, so we use put_action (which tolerates empty responses) and
+    /// follow up with a GET to return the installed license.
     pub async fn update(&self, request: LicenseUpdateRequest) -> Result<License> {
-        self.client.put("/v1/license", &request).await
+        self.client.put_action("/v1/license", &request).await?;
+        self.get().await
     }
 
     /// Get license usage statistics

--- a/tests/license_tests.rs
+++ b/tests/license_tests.rs
@@ -104,10 +104,19 @@ async fn test_license_update() {
         license: "new-license-key-12345".to_string(),
     };
 
+    // PUT /v1/license returns 200 with empty body (real API behavior)
     Mock::given(method("PUT"))
         .and(path("/v1/license"))
         .and(basic_auth("admin", "password"))
         .and(body_json(&update_request))
+        .respond_with(ResponseTemplate::new(200))
+        .mount(&mock_server)
+        .await;
+
+    // Follow-up GET /v1/license returns the installed license
+    Mock::given(method("GET"))
+        .and(path("/v1/license"))
+        .and(basic_auth("admin", "password"))
         .respond_with(success_response(json!({
             "key": "new-license-key-12345",
             "type": "production",


### PR DESCRIPTION
## Summary

`PUT /v1/license` returns `200 OK` with an empty body on some Redis Enterprise clusters, but the client tried to deserialize it as JSON, causing an EOF parse error even though the upload succeeded.

- Adds `put_action()` method (matching existing `post_action` pattern) for endpoints that return no content
- `LicenseHandler::update()` now uses `put_action` + a follow-up `GET /v1/license` to return the installed license
- Updates test to mock the real API behavior (empty PUT response + GET follow-up)

Fixes redis-developer/redisctl#895