### PR TITLE
chore: release v0.8.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.7](https://github.com/redis-developer/redis-enterprise-rs/compare/v0.8.6...v0.8.7) - 2026-03-19
+
+### Fixed
+
+- handle empty 200 response from PUT /v1/license ([#39](https://github.com/redis-developer/redis-enterprise-rs/pull/39))
+
+### Other
+
+- release v0.9.0 ([#37](https://github.com/redis-developer/redis-enterprise-rs/pull/37))
+
 ## [0.8.6](https://github.com/redis-developer/redis-enterprise-rs/compare/v0.8.5...v0.8.6) - 2026-03-19
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1158,7 +1158,7 @@ dependencies = [
 
 [[package]]
 name = "redis-enterprise"
-version = "0.8.6"
+version = "0.8.7"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "redis-enterprise"
-version = "0.8.6"
+version = "0.8.7"
 edition = "2024"
 rust-version = "1.89"
 authors = ["Josh Rotenberg <josh.rotenberg@redis.com>"]


### PR DESCRIPTION



## 🤖 New release

* `redis-enterprise`: 0.8.6 -> 0.8.7 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.8.7](https://github.com/redis-developer/redis-enterprise-rs/compare/v0.8.6...v0.8.7) - 2026-03-19

### Fixed

- handle empty 200 response from PUT /v1/license ([#39](https://github.com/redis-developer/redis-enterprise-rs/pull/39))

### Other

- release v0.9.0 ([#37](https://github.com/redis-developer/redis-enterprise-rs/pull/37))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).