### PR TITLE
fix(builder): reject missing credentials

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -174,8 +174,18 @@ impl EnterpriseClientBuilder {
 
     /// Build the client
     pub fn build(self) -> Result<EnterpriseClient> {
-        let username = self.username.unwrap_or_default();
-        let password = self.password.unwrap_or_default();
+        let username = self
+            .username
+            .filter(|value| !value.trim().is_empty())
+            .ok_or_else(|| {
+                RestError::ValidationError("Enterprise client username is required".to_string())
+            })?;
+        let password = self
+            .password
+            .filter(|value| !value.trim().is_empty())
+            .ok_or_else(|| {
+                RestError::ValidationError("Enterprise client password is required".to_string())
+            })?;
 
         let mut default_headers = HeaderMap::new();
         default_headers.insert(

--- a/src/lib_tests.rs
+++ b/src/lib_tests.rs
@@ -28,6 +28,67 @@ mod tests {
         assert!(result.is_ok());
     }
 
+    #[test]
+    fn test_enterprise_client_builder_requires_username() {
+        let result = EnterpriseClient::builder()
+            .base_url("https://example.com")
+            .password("test_pass")
+            .build();
+
+        match result {
+            Err(RestError::ValidationError(message)) => {
+                assert!(
+                    message.contains("username"),
+                    "unexpected message: {message}"
+                );
+            }
+            Err(err) => panic!("expected validation error, got: {err}"),
+            Ok(_) => panic!("expected missing username to fail"),
+        }
+    }
+
+    #[test]
+    fn test_enterprise_client_builder_requires_password() {
+        let result = EnterpriseClient::builder()
+            .base_url("https://example.com")
+            .username("test_user")
+            .build();
+
+        match result {
+            Err(RestError::ValidationError(message)) => {
+                assert!(
+                    message.contains("password"),
+                    "unexpected message: {message}"
+                );
+            }
+            Err(err) => panic!("expected validation error, got: {err}"),
+            Ok(_) => panic!("expected missing password to fail"),
+        }
+    }
+
+    #[test]
+    fn test_enterprise_client_builder_rejects_blank_credentials() {
+        let missing_username = EnterpriseClient::builder()
+            .base_url("https://example.com")
+            .username("   ")
+            .password("test_pass")
+            .build();
+        let missing_password = EnterpriseClient::builder()
+            .base_url("https://example.com")
+            .username("test_user")
+            .password("   ")
+            .build();
+
+        assert!(matches!(
+            missing_username,
+            Err(RestError::ValidationError(message)) if message.contains("username")
+        ));
+        assert!(matches!(
+            missing_password,
+            Err(RestError::ValidationError(message)) if message.contains("password")
+        ));
+    }
+
     #[tokio::test]
     async fn test_enterprise_client_get_request() {
         // Start a background HTTP server on a random local port


### PR DESCRIPTION
## Summary
- fail fast in `EnterpriseClientBuilder::build()` when username or password is missing
- reject blank credential strings instead of silently defaulting them to empty basic auth values
- add focused builder tests covering missing and whitespace-only credentials

## Testing
- cargo fmt
- cargo test

Closes #42
