### PR TITLE
docs(env): document CA cert variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,7 @@ dbs = client.databases_sync()
 - `REDIS_ENTERPRISE_USER` - Username
 - `REDIS_ENTERPRISE_PASSWORD` - Password
 - `REDIS_ENTERPRISE_INSECURE` - Set to "true" for self-signed certs
+- `REDIS_ENTERPRISE_CA_CERT` - Path to a custom CA certificate PEM file
 
 ## API Coverage
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,6 +32,7 @@
 //! - `REDIS_ENTERPRISE_USER`: Username for authentication
 //! - `REDIS_ENTERPRISE_PASSWORD`: Password for authentication
 //! - `REDIS_ENTERPRISE_INSECURE`: Set to `true` to skip SSL verification (dev only)
+//! - `REDIS_ENTERPRISE_CA_CERT`: Path to a custom CA certificate PEM file
 //!
 //! # Module Organization
 //!


### PR DESCRIPTION
## Summary
- document `REDIS_ENTERPRISE_CA_CERT` in the README environment variable list
- add the same variable to the crate-level environment variable docs so published docs match `from_env()`

## Testing
- not run (docs-only change)

Closes #43
