### PR TITLE
docs: update dependency versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,10 +28,10 @@ A comprehensive Rust client library for the Redis Enterprise REST API, with Pyth
 
 ```toml
 [dependencies]
-redis-enterprise = "0.7"
+redis-enterprise = "0.8.7"
 
 # Optional: Enable Tower service integration
-redis-enterprise = { version = "0.7", features = ["tower-integration"] }
+redis-enterprise = { version = "0.8.7", features = ["tower-integration"] }
 ```
 
 ## Quick Start

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,7 +21,7 @@
 //! Add to your `Cargo.toml`:
 //! ```toml
 //! [dependencies]
-//! redis-enterprise = "0.7"
+//! redis-enterprise = "0.8.7"
 //! tokio = { version = "1", features = ["full"] }
 //! ```
 //!


### PR DESCRIPTION
## Summary
- update the README dependency examples to the current published crate version
- update the crate-level docs install snippet to the same version
- keep the public install docs aligned with `Cargo.toml`

## Testing
- not run (docs-only change)

Closes #41
