### PR TITLE
fix(deps): update aws-lc-sys and rustls-webpki for 6 RUSTSEC advisories

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -133,9 +133,9 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.15.4"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b7b6141e96a8c160799cc2d5adecd5cbbe5054cb8c7c4af53da0f83bb7ad256"
+checksum = "5ec2f1fc3ec205783a5da9a7e6c1509cc69dedf09a1949e412c1e18469326d00"
 dependencies = [
  "aws-lc-sys",
  "zeroize",
@@ -143,9 +143,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.37.0"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c34dda4df7017c8db52132f0f8a2e0f8161649d15723ed63fc00c82d0f2081a"
+checksum = "1a2f9779ce85b93ab6170dd940ad0169b5766ff848247aff13bb788b832fe3f4"
 dependencies = [
  "cc",
  "cmake",
@@ -1346,9 +1346,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.9"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "aws-lc-rs",
  "ring",


### PR DESCRIPTION
## Summary

Cargo.lock-only update fixing six RUSTSEC advisories that have been flagged by cargo-deny.

| Crate | Before | After | Advisories |
|---|---|---|---|
| `aws-lc-rs` | 1.15.4 | 1.17.0 | (transitive) |
| `aws-lc-sys` | 0.37.0 | 0.41.0 | RUSTSEC-2026-0044, RUSTSEC-2026-0045 |
| `rustls-webpki` | 0.103.9 | 0.103.13 | RUSTSEC-2026-0049, -0098, -0099, -0104 |

## Why both crates

Bumping aws-lc-sys directly fails: `aws-lc-rs 1.15.4` pins `aws-lc-sys = "^0.37.0"` which excludes the patched 0.39+ range by semver. Bumping `aws-lc-rs` to `1.17.0` relaxes that. With aws-lc fixed, `rustls-webpki` advisories also surface in cargo-deny output and get the same treatment.

## Pattern

Mirrors:
- redis-enterprise-rs #34 (`fix: update quinn-proto to 0.11.14 (RUSTSEC-2026-0037)`)
- redis-cloud-rs #83 (this exact pair of crates, merged 2026-05-15)

## Test plan

- [x] `cargo deny check advisories` — `advisories ok`
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo test --workspace` — all pass (4 ignored = live_enterprise_smoke, by design)
- [x] No source files changed; only `Cargo.lock`

Closes #68