### PR TITLE
fix(stats, crdb_tasks): handle real-API response shapes and use the documented action endpoints

### DIFF
--- a/src/crdb_tasks.rs
+++ b/src/crdb_tasks.rs
@@ -81,8 +81,22 @@ impl CrdbTasksHandler {
     /// Cancel a CRDB task
     pub async fn cancel(&self, task_id: &str) -> Result<()> {
         self.client
-            .delete(&format!("/v1/crdb_tasks/{}", task_id))
+            .post_action(
+                &format!("/v1/crdb_tasks/{}/actions/cancel", task_id),
+                &serde_json::json!({}),
+            )
             .await
+    }
+
+    /// Cancel a CRDB task with optional force mode
+    pub async fn cancel_with_force(&self, task_id: &str, force: bool) -> Result<()> {
+        let path = if force {
+            format!("/v1/crdb_tasks/{}/actions/cancel?force=true", task_id)
+        } else {
+            format!("/v1/crdb_tasks/{}/actions/cancel", task_id)
+        };
+
+        self.client.post_action(&path, &serde_json::json!({})).await
     }
 
     /// Get tasks for a specific CRDB

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -57,7 +57,7 @@
 use crate::client::RestClient;
 use crate::error::Result;
 use futures::stream::Stream;
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize};
 use serde_json::Value;
 use std::pin::Pin;
 use std::time::Duration;
@@ -88,12 +88,49 @@ pub struct StatsResponse {
 }
 
 /// Stats interval
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize)]
 pub struct StatsInterval {
     /// Timestamp for this interval (ISO 8601 format)
     pub time: String,
     /// Metrics data for this time interval (dynamic field names)
     pub metrics: Value,
+}
+
+impl<'de> Deserialize<'de> for StatsInterval {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let value = Value::deserialize(deserializer)?;
+        let object = value.as_object().ok_or_else(|| {
+            <D::Error as serde::de::Error>::custom("expected stats interval object")
+        })?;
+
+        if let (Some(time), Some(metrics)) = (
+            object.get("time").and_then(Value::as_str),
+            object.get("metrics"),
+        ) {
+            return Ok(Self {
+                time: time.to_string(),
+                metrics: metrics.clone(),
+            });
+        }
+
+        let time = object
+            .get("stime")
+            .and_then(Value::as_str)
+            .or_else(|| object.get("etime").and_then(Value::as_str))
+            .ok_or_else(|| {
+                <D::Error as serde::de::Error>::custom(
+                    "expected stats interval to contain either time or stime/etime",
+                )
+            })?;
+
+        Ok(Self {
+            time: time.to_string(),
+            metrics: value,
+        })
+    }
 }
 
 /// Last stats response for single resource
@@ -112,10 +149,29 @@ pub struct LastStatsResponse {
 }
 
 /// Aggregated stats response for multiple resources
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize)]
 pub struct AggregatedStatsResponse {
     /// Array of stats for individual resources (nodes, databases, shards)
     pub stats: Vec<ResourceStats>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(untagged)]
+enum AggregatedStatsResponseWire {
+    Wrapped { stats: Vec<ResourceStats> },
+    Bare(Vec<ResourceStats>),
+}
+
+impl<'de> Deserialize<'de> for AggregatedStatsResponse {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        match AggregatedStatsResponseWire::deserialize(deserializer)? {
+            AggregatedStatsResponseWire::Wrapped { stats } => Ok(Self { stats }),
+            AggregatedStatsResponseWire::Bare(stats) => Ok(Self { stats }),
+        }
+    }
 }
 
 /// Stats for a single resource
@@ -269,10 +325,10 @@ impl StatsHandler {
         if let Some(q) = query {
             let query_str = serde_urlencoded::to_string(&q).unwrap_or_default();
             self.client
-                .get(&format!("/v1/shards/{}/stats?{}", uid, query_str))
+                .get(&format!("/v1/shards/stats/{}?{}", uid, query_str))
                 .await
         } else {
-            self.client.get(&format!("/v1/shards/{}/stats", uid)).await
+            self.client.get(&format!("/v1/shards/stats/{}", uid)).await
         }
     }
 
@@ -289,6 +345,18 @@ impl StatsHandler {
     }
 
     // raw variant removed: use shards()
+
+    /// Get all shards last stats
+    pub async fn shards_last(&self) -> Result<Value> {
+        self.client.get("/v1/shards/stats/last").await
+    }
+
+    /// Get shard last stats
+    pub async fn shard_last(&self, uid: u32) -> Result<Value> {
+        self.client
+            .get(&format!("/v1/shards/stats/last/{}", uid))
+            .await
+    }
 
     /// Stream cluster stats in real-time by polling
     ///

--- a/tests/crdb_tasks_tests.rs
+++ b/tests/crdb_tasks_tests.rs
@@ -360,8 +360,8 @@ async fn test_crdb_tasks_create_invalid() {
 async fn test_crdb_tasks_cancel() {
     let mock_server = MockServer::start().await;
 
-    Mock::given(method("DELETE"))
-        .and(path("/v1/crdb_tasks/task-123"))
+    Mock::given(method("POST"))
+        .and(path("/v1/crdb_tasks/task-123/actions/cancel"))
         .and(basic_auth("admin", "password"))
         .respond_with(no_content_response())
         .mount(&mock_server)
@@ -384,8 +384,8 @@ async fn test_crdb_tasks_cancel() {
 async fn test_crdb_tasks_cancel_nonexistent() {
     let mock_server = MockServer::start().await;
 
-    Mock::given(method("DELETE"))
-        .and(path("/v1/crdb_tasks/nonexistent"))
+    Mock::given(method("POST"))
+        .and(path("/v1/crdb_tasks/nonexistent/actions/cancel"))
         .and(basic_auth("admin", "password"))
         .respond_with(error_response(404, "Task not found"))
         .mount(&mock_server)
@@ -408,8 +408,8 @@ async fn test_crdb_tasks_cancel_nonexistent() {
 async fn test_crdb_tasks_cancel_completed() {
     let mock_server = MockServer::start().await;
 
-    Mock::given(method("DELETE"))
-        .and(path("/v1/crdb_tasks/task-789"))
+    Mock::given(method("POST"))
+        .and(path("/v1/crdb_tasks/task-789/actions/cancel"))
         .and(basic_auth("admin", "password"))
         .respond_with(error_response(400, "Cannot cancel completed task"))
         .mount(&mock_server)
@@ -426,6 +426,31 @@ async fn test_crdb_tasks_cancel_completed() {
     let result = handler.cancel("task-789").await;
 
     assert!(result.is_err());
+}
+
+#[tokio::test]
+async fn test_crdb_tasks_cancel_force() {
+    let mock_server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .and(path("/v1/crdb_tasks/task-123/actions/cancel"))
+        .and(wiremock::matchers::query_param("force", "true"))
+        .and(basic_auth("admin", "password"))
+        .respond_with(no_content_response())
+        .mount(&mock_server)
+        .await;
+
+    let client = EnterpriseClient::builder()
+        .base_url(mock_server.uri())
+        .username("admin")
+        .password("password")
+        .build()
+        .unwrap();
+
+    let handler = CrdbTasksHandler::new(client);
+    let result = handler.cancel_with_force("task-123", true).await;
+
+    assert!(result.is_ok());
 }
 
 #[tokio::test]

--- a/tests/stats_tests.rs
+++ b/tests/stats_tests.rs
@@ -86,14 +86,14 @@ fn test_shard_stats() -> serde_json::Value {
     json!({
         "intervals": [
             {
-                "time": "2023-01-01T12:00:00Z",
-                "metrics": {
-                    "used_memory": 524288,
-                    "total_req": 2500,
-                    "ops_per_sec": 50.0,
-                    "keyspace_hits": 2250,
-                    "keyspace_misses": 250
-                }
+                "stime": "2023-01-01T12:00:00Z",
+                "etime": "2023-01-01T12:01:00Z",
+                "interval": "1min",
+                "used_memory": 524288,
+                "total_req": 2500,
+                "ops_per_sec": 50.0,
+                "keyspace_hits": 2250,
+                "keyspace_misses": 250
             }
         ]
     })
@@ -136,6 +136,19 @@ fn test_database_last_stats() -> serde_json::Value {
         "ops_per_sec": 105.2,
         "hits": 4680,
         "misses": 520
+    })
+}
+
+fn test_shards_last_stats() -> serde_json::Value {
+    json!({
+        "1": {
+            "used_memory": 524288,
+            "ops_per_sec": 50.0
+        },
+        "2": {
+            "used_memory": 262144,
+            "ops_per_sec": 25.0
+        }
     })
 }
 
@@ -531,7 +544,7 @@ async fn test_stats_shard() {
     let mock_server = MockServer::start().await;
 
     Mock::given(method("GET"))
-        .and(path("/v1/shards/1/stats"))
+        .and(path("/v1/shards/stats/1"))
         .and(basic_auth("admin", "password"))
         .respond_with(success_response(test_shard_stats()))
         .mount(&mock_server)
@@ -559,7 +572,7 @@ async fn test_stats_shard_nonexistent() {
     let mock_server = MockServer::start().await;
 
     Mock::given(method("GET"))
-        .and(path("/v1/shards/999/stats"))
+        .and(path("/v1/shards/stats/999"))
         .and(basic_auth("admin", "password"))
         .respond_with(error_response(404, "Shard not found"))
         .mount(&mock_server)
@@ -585,12 +598,10 @@ async fn test_stats_shards() {
     Mock::given(method("GET"))
         .and(path("/v1/shards/stats"))
         .and(basic_auth("admin", "password"))
-        .respond_with(success_response(json!({
-            "stats": [
-                {"uid": 1, "intervals": []},
-                {"uid": 2, "intervals": []}
-            ]
-        })))
+        .respond_with(success_response(json!([
+            {"uid": 1, "intervals": []},
+            {"uid": 2, "intervals": []}
+        ])))
         .mount(&mock_server)
         .await;
 
@@ -609,4 +620,57 @@ async fn test_stats_shards() {
     assert_eq!(stats.stats.len(), 2);
     assert_eq!(stats.stats[0].uid, 1);
     assert_eq!(stats.stats[1].uid, 2);
+}
+
+#[tokio::test]
+async fn test_stats_shards_last() {
+    let mock_server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/v1/shards/stats/last"))
+        .and(basic_auth("admin", "password"))
+        .respond_with(success_response(test_shards_last_stats()))
+        .mount(&mock_server)
+        .await;
+
+    let client = EnterpriseClient::builder()
+        .base_url(mock_server.uri())
+        .username("admin")
+        .password("password")
+        .build()
+        .unwrap();
+
+    let handler = StatsHandler::new(client);
+    let stats = handler.shards_last().await.unwrap();
+    assert_eq!(stats["1"]["ops_per_sec"], 50.0);
+    assert_eq!(stats["2"]["used_memory"], 262144);
+}
+
+#[tokio::test]
+async fn test_stats_shard_last() {
+    let mock_server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/v1/shards/stats/last/1"))
+        .and(basic_auth("admin", "password"))
+        .respond_with(success_response(json!({
+            "1": {
+                "used_memory": 524288,
+                "ops_per_sec": 50.0
+            }
+        })))
+        .mount(&mock_server)
+        .await;
+
+    let client = EnterpriseClient::builder()
+        .base_url(mock_server.uri())
+        .username("admin")
+        .password("password")
+        .build()
+        .unwrap();
+
+    let handler = StatsHandler::new(client);
+    let stats = handler.shard_last(1).await.unwrap();
+    assert_eq!(stats["1"]["used_memory"], 524288);
+    assert_eq!(stats["1"]["ops_per_sec"], 50.0);
 }


### PR DESCRIPTION
## Summary

Two correctness fixes pulled from in-flight refresh work, both verified against live Redis Enterprise 8.0.10-81.

### `src/stats.rs`

Adds custom `Deserialize` impls to handle the wire-shape variations the real API returns:

- **`StatsInterval`**: API uses `{time, metrics}` on most endpoints but `{stime, etime, ...}` on aggregated/bdb stats. The serde derive could only decode one shape; the custom impl accepts both.
- **`AggregatedStatsResponse`**: spec says response wraps stats under `stats`, but in practice some endpoints return a bare array. Accepts both shapes — same wrapper-decode pattern called out in #62.
- **Path fix**: `/v1/shards/{uid}/stats` is not documented; the spec uses `/v1/shards/stats/{uid}`. Method now hits the correct path.
- **New methods**: `shards_last()` and `shard_last(uid)` mirroring the existing `*_last` pattern on other resources.

### `src/crdb_tasks.rs`

- `cancel()` now POSTs to `/v1/crdb_tasks/{task_id}/actions/cancel`, the documented verb + path. The previous implementation sent `DELETE /v1/crdb_tasks/{task_id}` which is not in the spec.
- Adds `cancel_with_force(task_id, force)` for the `force=true` query parameter case.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace` — all pass; new tests cover the shape variations and the new verb

Refs #62 (wrapper-decode umbrella; stats portion now closed in code)