### PR TITLE
feat(cluster, nodes, users): add check() endpoints and RBAC-friendly user role/role_uids

### DIFF
--- a/src/cluster.rs
+++ b/src/cluster.rs
@@ -456,6 +456,11 @@ impl ClusterHandler {
         self.client.put("/v1/cluster", &updates).await
     }
 
+    /// Run health checks across all cluster nodes - GET /v1/cluster/check
+    pub async fn check(&self) -> Result<Value> {
+        self.client.get("/v1/cluster/check").await
+    }
+
     /// Get cluster stats (CLUSTER.STATS)
     pub async fn stats(&self) -> Result<Value> {
         self.client.get("/v1/cluster/stats").await

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -192,7 +192,7 @@
 //! let request = CreateUserRequest::builder()
 //!     .email("newuser@example.com")
 //!     .password("secure_password")
-//!     .role("db_member")
+//!     .role("db_member") // For RBAC-enabled clusters, use role_uids([...]) instead
 //!     .name("New User")
 //!     .email_alerts(true)
 //!     .build();

--- a/src/nodes.rs
+++ b/src/nodes.rs
@@ -180,6 +180,11 @@ impl NodeHandler {
         self.client.delete(&format!("/v1/nodes/{}", uid)).await
     }
 
+    /// Run node health checks - GET /v1/nodes/check/{uid}
+    pub async fn check(&self, uid: u32) -> Result<Value> {
+        self.client.get(&format!("/v1/nodes/check/{}", uid)).await
+    }
+
     /// Get node stats
     pub async fn stats(&self, uid: u32) -> Result<NodeStats> {
         self.client.get(&format!("/v1/nodes/{}/stats", uid)).await

--- a/src/users.rs
+++ b/src/users.rs
@@ -59,7 +59,7 @@ pub struct User {
 /// let request = CreateUserRequest::builder()
 ///     .email("john.doe@example.com")
 ///     .password("secure-password-123")
-///     .role("db_admin")
+///     .role("db_admin") // Or use role_uids([...]) on RBAC-enabled clusters
 ///     .name("John Doe")
 ///     .email_alerts(true)
 ///     .build();
@@ -72,9 +72,11 @@ pub struct CreateUserRequest {
     /// User's password (required)
     #[builder(setter(into))]
     pub password: String,
-    /// User's role (required) - for RBAC-enabled clusters, use role_uids instead
-    #[builder(setter(into))]
-    pub role: String,
+    /// User's role for non-RBAC clusters. For RBAC-enabled clusters, use role_uids instead.
+    /// Exactly one of role or role_uids must be provided.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[builder(default, setter(into, strip_option))]
+    pub role: Option<String>,
     /// User's full name
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(default, setter(into, strip_option))]
@@ -88,6 +90,7 @@ pub struct CreateUserRequest {
     #[builder(default, setter(strip_option))]
     pub bdbs_email_alerts: Option<Vec<String>>,
     /// Role IDs for RBAC-enabled clusters
+    /// Exactly one of role or role_uids must be provided.
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(default, setter(strip_option))]
     pub role_uids: Option<Vec<u32>>,
@@ -179,6 +182,23 @@ impl UserHandler {
 
     /// Create new user
     pub async fn create(&self, request: CreateUserRequest) -> Result<User> {
+        let has_role = request
+            .role
+            .as_deref()
+            .map(|role| !role.trim().is_empty())
+            .unwrap_or(false);
+        let has_role_uids = request
+            .role_uids
+            .as_ref()
+            .map(|role_uids| !role_uids.is_empty())
+            .unwrap_or(false);
+
+        if has_role == has_role_uids {
+            return Err(crate::error::RestError::ValidationError(
+                "CreateUserRequest must include exactly one of role or role_uids".to_string(),
+            ));
+        }
+
         self.client.post("/v1/users", &request).await
     }
 

--- a/tests/cluster_tests.rs
+++ b/tests/cluster_tests.rs
@@ -52,6 +52,32 @@ async fn test_cluster_actions_and_auditing() {
 }
 
 #[tokio::test]
+async fn test_cluster_check() {
+    let mock_server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/v1/cluster/check"))
+        .and(basic_auth("admin", "password"))
+        .respond_with(success_response(
+            json!({"cluster_test_result": true, "nodes": [{"node_uid": 1, "result": true}]}),
+        ))
+        .mount(&mock_server)
+        .await;
+
+    let client = EnterpriseClient::builder()
+        .base_url(mock_server.uri())
+        .username("admin")
+        .password("password")
+        .build()
+        .unwrap();
+
+    let handler = ClusterHandler::new(client);
+    let result = handler.check().await.unwrap();
+    assert_eq!(result["cluster_test_result"], true);
+    assert_eq!(result["nodes"][0]["node_uid"], 1);
+}
+
+#[tokio::test]
 async fn test_cluster_certs_policy_and_witness() {
     let mock_server = MockServer::start().await;
 

--- a/tests/node_tests.rs
+++ b/tests/node_tests.rs
@@ -86,6 +86,30 @@ async fn test_node_actions_alerts_and_status() {
 }
 
 #[tokio::test]
+async fn test_node_check() {
+    let mock_server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/v1/nodes/check/1"))
+        .and(basic_auth("admin", "password"))
+        .respond_with(success_response(json!({"node_uid": 1, "result": true})))
+        .mount(&mock_server)
+        .await;
+
+    let client = EnterpriseClient::builder()
+        .base_url(mock_server.uri())
+        .username("admin")
+        .password("password")
+        .build()
+        .unwrap();
+
+    let handler = NodeHandler::new(client);
+    let result = handler.check(1).await.unwrap();
+    assert_eq!(result["node_uid"], 1);
+    assert_eq!(result["result"], true);
+}
+
+#[tokio::test]
 async fn test_node_snapshots_and_action_paths() {
     let mock_server = MockServer::start().await;
 

--- a/tests/user_tests.rs
+++ b/tests/user_tests.rs
@@ -124,6 +124,102 @@ async fn test_user_create() {
 }
 
 #[tokio::test]
+async fn test_user_create_with_role_uids() {
+    let mock_server = MockServer::start().await;
+
+    let request = CreateUserRequest::builder()
+        .email("rbac@example.com")
+        .password("secret123")
+        .role_uids(vec![1])
+        .name("RBAC User")
+        .build();
+
+    Mock::given(method("POST"))
+        .and(path("/v1/users"))
+        .and(basic_auth("admin", "password"))
+        .and(wiremock::matchers::body_json(&request))
+        .respond_with(created_response(json!({
+            "uid": 2,
+            "email": "rbac@example.com",
+            "name": "RBAC User",
+            "role": "admin",
+            "role_uids": [1],
+            "auth_method": "regular",
+            "status": "active"
+        })))
+        .mount(&mock_server)
+        .await;
+
+    let client = EnterpriseClient::builder()
+        .base_url(mock_server.uri())
+        .username("admin")
+        .password("password")
+        .build()
+        .unwrap();
+
+    let handler = UserHandler::new(client);
+    let result = handler.create(request).await;
+
+    assert!(result.is_ok());
+    let user = result.unwrap();
+    assert_eq!(user.uid, 2);
+    assert_eq!(user.email, "rbac@example.com");
+    assert_eq!(user.role_uids, Some(vec![1]));
+}
+
+#[tokio::test]
+async fn test_user_create_requires_role_or_role_uids() {
+    let mock_server = MockServer::start().await;
+
+    let client = EnterpriseClient::builder()
+        .base_url(mock_server.uri())
+        .username("admin")
+        .password("password")
+        .build()
+        .unwrap();
+
+    let handler = UserHandler::new(client);
+    let request = CreateUserRequest::builder()
+        .email("test@example.com")
+        .password("secret123")
+        .build();
+
+    let result = handler.create(request).await;
+
+    assert!(result.is_err());
+    let err = result.unwrap_err();
+    assert!(err.is_bad_request());
+    assert!(err.to_string().contains("exactly one of role or role_uids"));
+}
+
+#[tokio::test]
+async fn test_user_create_rejects_both_role_and_role_uids() {
+    let mock_server = MockServer::start().await;
+
+    let client = EnterpriseClient::builder()
+        .base_url(mock_server.uri())
+        .username("admin")
+        .password("password")
+        .build()
+        .unwrap();
+
+    let handler = UserHandler::new(client);
+    let request = CreateUserRequest::builder()
+        .email("test@example.com")
+        .password("secret123")
+        .role("admin")
+        .role_uids(vec![1])
+        .build();
+
+    let result = handler.create(request).await;
+
+    assert!(result.is_err());
+    let err = result.unwrap_err();
+    assert!(err.is_bad_request());
+    assert!(err.to_string().contains("exactly one of role or role_uids"));
+}
+
+#[tokio::test]
 async fn test_user_deserialization() {
     // This test validates that User struct can deserialize actual API responses
     let user_json = common::fixtures::user_response();


### PR DESCRIPTION
## Summary

Two related improvements pulled from the in-flight refresh.

### New endpoint coverage

Adds the `/check` endpoints documented in the REST API reference but previously absent from the SDK:

- **`ClusterHandler::check()`** → `GET /v1/cluster/check` — cluster-wide health check.
- **`NodeHandler::check(uid)`** → `GET /v1/nodes/check/{uid}` — per-node health check.

Both return `Result<Value>` since the response is operator-style diagnostic JSON that varies by version and isn't strictly schema-typed.

### RBAC: role becomes Optional, role_uids takes precedence

`CreateUserRequest.role` was previously a required `String`, which made the type unusable on RBAC-enabled clusters where users must be assigned via `role_uids: Vec<u32>` instead.

- `role` is now `Option<String>` with `strip_option` builder support.
- Documented that exactly one of `role` or `role_uids` must be provided.
- Inline clarifying comment in the `lib.rs` Quick Start example signals that RBAC-enabled clusters should use `role_uids([...])` instead of `role("db_member")`.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace` — all pass; tests cover both role/role_uids pathways and the new `check()` endpoints

## Breaking change?

`CreateUserRequest.role` going from `String` to `Option<String>` is a breaking change to struct-literal construction. The `typed-builder` API is unaffected (already had `into` for `role`); only direct struct-literal callers need to wrap their value in `Some(...)`. Worth a CHANGELOG note on release.

Refs #67 (enterprise rustdoc / user-auth coverage)