### PR TITLE
chore: release v0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,46 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.0](https://github.com/redis-developer/redis-enterprise-rs/compare/v0.8.7...v0.9.0) - 2026-05-26
+
+### Added
+
+- *(modules)* add user-defined module management endpoints ([#90](https://github.com/redis-developer/redis-enterprise-rs/pull/90))
+- *(cluster)* add SSO and SAML metadata endpoints ([#89](https://github.com/redis-developer/redis-enterprise-rs/pull/89))
+- *(crdb)* add flush, health_report, purge, and updates endpoints ([#88](https://github.com/redis-developer/redis-enterprise-rs/pull/88))
+- *(cluster)* add change_password_hashing_algorithm endpoint ([#87](https://github.com/redis-developer/redis-enterprise-rs/pull/87))
+- *(cluster, nodes, users)* add check() endpoints and RBAC-friendly user role/role_uids ([#72](https://github.com/redis-developer/redis-enterprise-rs/pull/72))
+
+### Fixed
+
+- *(alerts)* list_cluster_alerts returns HashMap<String, ClusterAlertState> ([#83](https://github.com/redis-developer/redis-enterprise-rs/pull/83))
+- *(bootstrap)* reshape status response to match the documented spec wrapper ([#82](https://github.com/redis-developer/redis-enterprise-rs/pull/82))
+- *(types)* unwrap {crdbs} / {bdb_groups} wrappers on list endpoints ([#81](https://github.com/redis-developer/redis-enterprise-rs/pull/81))
+- *(proxies)* make optional fields Optional and widen maxmemory_clients to u64 ([#80](https://github.com/redis-developer/redis-enterprise-rs/pull/80))
+- *(actions)* correctly decode the {actions, state-machines} wrapper; string-typed progress/node_uid ([#79](https://github.com/redis-developer/redis-enterprise-rs/pull/79))
+- *(builder)* reject missing credentials ([#44](https://github.com/redis-developer/redis-enterprise-rs/pull/44))
+- *(ocsp)* test() uses POST (the documented verb), not GET ([#78](https://github.com/redis-developer/redis-enterprise-rs/pull/78))
+- *(nodes)* execute_action POSTs to /v1/nodes/{uid}/actions/{action}, the documented path ([#77](https://github.com/redis-developer/redis-enterprise-rs/pull/77))
+- *(bdb)* flush() and reset_admin_pass() use the documented PUT path-segment endpoints ([#76](https://github.com/redis-developer/redis-enterprise-rs/pull/76))
+- *(crdb)* UPDATE uses PATCH verb (the documented one), not PUT ([#75](https://github.com/redis-developer/redis-enterprise-rs/pull/75))
+- *(stats, crdb_tasks)* handle real-API response shapes and use the documented action endpoints ([#71](https://github.com/redis-developer/redis-enterprise-rs/pull/71))
+
+### Other
+
+- README + examples refresh for v0.9.0 ([#96](https://github.com/redis-developer/redis-enterprise-rs/pull/96))
+- remove fictional services / jsonschema / usage_report routes ([#95](https://github.com/redis-developer/redis-enterprise-rs/pull/95))
+- *(bdb)* remove fictional actions/{backup,restore,upgrade} ([#94](https://github.com/redis-developer/redis-enterprise-rs/pull/94))
+- *(alerts)* remove fictional /v1/alerts* top-level routes ([#93](https://github.com/redis-developer/redis-enterprise-rs/pull/93))
+- *(audit)* per-route triage for the 122 non-spec SDK routes ([#92](https://github.com/redis-developer/redis-enterprise-rs/pull/92))
+- *(live-validation)* add TLS, licensing, and teardown sections; link from README ([#91](https://github.com/redis-developer/redis-enterprise-rs/pull/91))
+- enforce #![deny(missing_docs)] and rustdoc::broken_intra_doc_links ([#86](https://github.com/redis-developer/redis-enterprise-rs/pull/86))
+- *(missing-docs)* document fields and enum variants across the crate ([#85](https://github.com/redis-developer/redis-enterprise-rs/pull/85))
+- *(coverage)* add route-coverage test against the docs API inventory ([#84](https://github.com/redis-developer/redis-enterprise-rs/pull/84))
+- update dependency versions ([#46](https://github.com/redis-developer/redis-enterprise-rs/pull/46))
+- *(env)* document CA cert variable ([#45](https://github.com/redis-developer/redis-enterprise-rs/pull/45))
+- *(live)* add opt-in live integration smoke tests against a real Redis Enterprise cluster ([#74](https://github.com/redis-developer/redis-enterprise-rs/pull/74))
+- *(infra)* add API audit docs + scripts and modernize docker-compose ([#70](https://github.com/redis-developer/redis-enterprise-rs/pull/70))
+
 ## [0.8.7](https://github.com/redis-developer/redis-enterprise-rs/compare/v0.8.6...v0.8.7) - 2026-03-19
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1158,7 +1158,7 @@ dependencies = [
 
 [[package]]
 name = "redis-enterprise"
-version = "0.8.7"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "redis-enterprise"
-version = "0.8.7"
+version = "0.9.0"
 edition = "2024"
 rust-version = "1.89"
 authors = ["Josh Rotenberg <josh.rotenberg@redis.com>"]


### PR DESCRIPTION



## 🤖 New release

* `redis-enterprise`: 0.8.7 -> 0.9.0 (⚠ API breaking changes)

### ⚠ `redis-enterprise` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.47.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field Action.creation_time in /tmp/.tmpHbifXw/redis-enterprise-rs/src/actions.rs:47
  field Action.task_id in /tmp/.tmpHbifXw/redis-enterprise-rs/src/actions.rs:50
  field Action.heartbeat in /tmp/.tmpHbifXw/redis-enterprise-rs/src/actions.rs:54
  field Action.object_name in /tmp/.tmpHbifXw/redis-enterprise-rs/src/actions.rs:58
  field Action.creation_time in /tmp/.tmpHbifXw/redis-enterprise-rs/src/actions.rs:47
  field Action.task_id in /tmp/.tmpHbifXw/redis-enterprise-rs/src/actions.rs:50
  field Action.heartbeat in /tmp/.tmpHbifXw/redis-enterprise-rs/src/actions.rs:54
  field Action.object_name in /tmp/.tmpHbifXw/redis-enterprise-rs/src/actions.rs:58
  field BootstrapStatus.state in /tmp/.tmpHbifXw/redis-enterprise-rs/src/bootstrap.rs:112
  field BootstrapStatus.start_time in /tmp/.tmpHbifXw/redis-enterprise-rs/src/bootstrap.rs:115
  field BootstrapStatus.end_time in /tmp/.tmpHbifXw/redis-enterprise-rs/src/bootstrap.rs:118
  field BootstrapStatus.state in /tmp/.tmpHbifXw/redis-enterprise-rs/src/bootstrap.rs:112
  field BootstrapStatus.start_time in /tmp/.tmpHbifXw/redis-enterprise-rs/src/bootstrap.rs:115
  field BootstrapStatus.end_time in /tmp/.tmpHbifXw/redis-enterprise-rs/src/bootstrap.rs:118

--- failure inherent_method_missing: pub method removed or renamed ---

Description:
A publicly-visible method or associated fn is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.47.0/src/lints/inherent_method_missing.ron

Failed in:
  MockEnterpriseServer::mock_alerts_list, previously in file /tmp/.tmps4mQGN/redis-enterprise/src/testing/server.rs:199
  MockEnterpriseServer::mock_alert_get, previously in file /tmp/.tmps4mQGN/redis-enterprise/src/testing/server.rs:208
  MockEnterpriseServer::mock_alerts_list, previously in file /tmp/.tmps4mQGN/redis-enterprise/src/testing/server.rs:199
  MockEnterpriseServer::mock_alert_get, previously in file /tmp/.tmps4mQGN/redis-enterprise/src/testing/server.rs:208
  AlertHandler::list, previously in file /tmp/.tmps4mQGN/redis-enterprise/src/alerts.rs:225
  AlertHandler::get, previously in file /tmp/.tmps4mQGN/redis-enterprise/src/alerts.rs:230
  AlertHandler::clear, previously in file /tmp/.tmps4mQGN/redis-enterprise/src/alerts.rs:308
  AlertHandler::clear_all, previously in file /tmp/.tmps4mQGN/redis-enterprise/src/alerts.rs:313
  AlertHandler::list, previously in file /tmp/.tmps4mQGN/redis-enterprise/src/alerts.rs:225
  AlertHandler::get, previously in file /tmp/.tmps4mQGN/redis-enterprise/src/alerts.rs:230
  AlertHandler::clear, previously in file /tmp/.tmps4mQGN/redis-enterprise/src/alerts.rs:308
  AlertHandler::clear_all, previously in file /tmp/.tmps4mQGN/redis-enterprise/src/alerts.rs:313
  AlertHandler::list, previously in file /tmp/.tmps4mQGN/redis-enterprise/src/alerts.rs:225
  AlertHandler::get, previously in file /tmp/.tmps4mQGN/redis-enterprise/src/alerts.rs:230
  AlertHandler::clear, previously in file /tmp/.tmps4mQGN/redis-enterprise/src/alerts.rs:308
  AlertHandler::clear_all, previously in file /tmp/.tmps4mQGN/redis-enterprise/src/alerts.rs:313
  DatabaseHandler::backup, previously in file /tmp/.tmps4mQGN/redis-enterprise/src/bdb.rs:623
  DatabaseHandler::restore, previously in file /tmp/.tmps4mQGN/redis-enterprise/src/bdb.rs:633
  DatabaseHandler::upgrade, previously in file /tmp/.tmps4mQGN/redis-enterprise/src/bdb.rs:905
  DatabaseHandler::backup, previously in file /tmp/.tmps4mQGN/redis-enterprise/src/bdb.rs:623
  DatabaseHandler::restore, previously in file /tmp/.tmps4mQGN/redis-enterprise/src/bdb.rs:633
  DatabaseHandler::upgrade, previously in file /tmp/.tmps4mQGN/redis-enterprise/src/bdb.rs:905
  DatabaseHandler::backup, previously in file /tmp/.tmps4mQGN/redis-enterprise/src/bdb.rs:623
  DatabaseHandler::restore, previously in file /tmp/.tmps4mQGN/redis-enterprise/src/bdb.rs:633
  DatabaseHandler::upgrade, previously in file /tmp/.tmps4mQGN/redis-enterprise/src/bdb.rs:905
  UsageReportHandler::latest, previously in file /tmp/.tmps4mQGN/redis-enterprise/src/usage_report.rs:119
  UsageReportHandler::get, previously in file /tmp/.tmps4mQGN/redis-enterprise/src/usage_report.rs:129
  UsageReportHandler::generate, previously in file /tmp/.tmps4mQGN/redis-enterprise/src/usage_report.rs:136
  UsageReportHandler::get_config, previously in file /tmp/.tmps4mQGN/redis-enterprise/src/usage_report.rs:143
  UsageReportHandler::update_config, previously in file /tmp/.tmps4mQGN/redis-enterprise/src/usage_report.rs:148
  UsageReportHandler::download_csv, previously in file /tmp/.tmps4mQGN/redis-enterprise/src/usage_report.rs:153
  UsageReportHandler::latest, previously in file /tmp/.tmps4mQGN/redis-enterprise/src/usage_report.rs:119
  UsageReportHandler::get, previously in file /tmp/.tmps4mQGN/redis-enterprise/src/usage_report.rs:129
  UsageReportHandler::generate, previously in file /tmp/.tmps4mQGN/redis-enterprise/src/usage_report.rs:136
  UsageReportHandler::get_config, previously in file /tmp/.tmps4mQGN/redis-enterprise/src/usage_report.rs:143
  UsageReportHandler::update_config, previously in file /tmp/.tmps4mQGN/redis-enterprise/src/usage_report.rs:148
  UsageReportHandler::download_csv, previously in file /tmp/.tmps4mQGN/redis-enterprise/src/usage_report.rs:153
  JsonSchemaHandler::get, previously in file /tmp/.tmps4mQGN/redis-enterprise/src/jsonschema.rs:28
  JsonSchemaHandler::database_schema, previously in file /tmp/.tmps4mQGN/redis-enterprise/src/jsonschema.rs:35
  JsonSchemaHandler::cluster_schema, previously in file /tmp/.tmps4mQGN/redis-enterprise/src/jsonschema.rs:40
  JsonSchemaHandler::node_schema, previously in file /tmp/.tmps4mQGN/redis-enterprise/src/jsonschema.rs:45
  JsonSchemaHandler::user_schema, previously in file /tmp/.tmps4mQGN/redis-enterprise/src/jsonschema.rs:50
  JsonSchemaHandler::crdb_schema, previously in file /tmp/.tmps4mQGN/redis-enterprise/src/jsonschema.rs:55
  JsonSchemaHandler::validate, previously in file /tmp/.tmps4mQGN/redis-enterprise/src/jsonschema.rs:60
  JsonSchemaHandler::get, previously in file /tmp/.tmps4mQGN/redis-enterprise/src/jsonschema.rs:28
  JsonSchemaHandler::database_schema, previously in file /tmp/.tmps4mQGN/redis-enterprise/src/jsonschema.rs:35
  JsonSchemaHandler::cluster_schema, previously in file /tmp/.tmps4mQGN/redis-enterprise/src/jsonschema.rs:40
  JsonSchemaHandler::node_schema, previously in file /tmp/.tmps4mQGN/redis-enterprise/src/jsonschema.rs:45
  JsonSchemaHandler::user_schema, previously in file /tmp/.tmps4mQGN/redis-enterprise/src/jsonschema.rs:50
  JsonSchemaHandler::crdb_schema, previously in file /tmp/.tmps4mQGN/redis-enterprise/src/jsonschema.rs:55
  JsonSchemaHandler::validate, previously in file /tmp/.tmps4mQGN/redis-enterprise/src/jsonschema.rs:60
  ServicesHandler::list, previously in file /tmp/.tmps4mQGN/redis-enterprise/src/services.rs:89
  ServicesHandler::get, previously in file /tmp/.tmps4mQGN/redis-enterprise/src/services.rs:94
  ServicesHandler::update, previously in file /tmp/.tmps4mQGN/redis-enterprise/src/services.rs:101
  ServicesHandler::status, previously in file /tmp/.tmps4mQGN/redis-enterprise/src/services.rs:108
  ServicesHandler::restart, previously in file /tmp/.tmps4mQGN/redis-enterprise/src/services.rs:115
  ServicesHandler::stop, previously in file /tmp/.tmps4mQGN/redis-enterprise/src/services.rs:125
  ServicesHandler::start, previously in file /tmp/.tmps4mQGN/redis-enterprise/src/services.rs:132
  ServicesHandler::list, previously in file /tmp/.tmps4mQGN/redis-enterprise/src/services.rs:89
  ServicesHandler::get, previously in file /tmp/.tmps4mQGN/redis-enterprise/src/services.rs:94
  ServicesHandler::update, previously in file /tmp/.tmps4mQGN/redis-enterprise/src/services.rs:101
  ServicesHandler::status, previously in file /tmp/.tmps4mQGN/redis-enterprise/src/services.rs:108
  ServicesHandler::restart, previously in file /tmp/.tmps4mQGN/redis-enterprise/src/services.rs:115
  ServicesHandler::stop, previously in file /tmp/.tmps4mQGN/redis-enterprise/src/services.rs:125
  ServicesHandler::start, previously in file /tmp/.tmps4mQGN/redis-enterprise/src/services.rs:132

--- failure struct_missing: pub struct removed or renamed ---

Description:
A publicly-visible struct cannot be imported by its prior path. A `pub use` may have been removed, or the struct itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.47.0/src/lints/struct_missing.ron

Failed in:
  struct redis_enterprise::services::ServiceStatus, previously in file /tmp/.tmps4mQGN/redis-enterprise/src/services.rs:53
  struct redis_enterprise::ServiceStatus, previously in file /tmp/.tmps4mQGN/redis-enterprise/src/services.rs:53
  struct redis_enterprise::services::ServiceConfigRequest, previously in file /tmp/.tmps4mQGN/redis-enterprise/src/services.rs:38
  struct redis_enterprise::ServiceConfigRequest, previously in file /tmp/.tmps4mQGN/redis-enterprise/src/services.rs:38
  struct redis_enterprise::services::NodeServiceStatus, previously in file /tmp/.tmps4mQGN/redis-enterprise/src/services.rs:68
  struct redis_enterprise::NodeServiceStatus, previously in file /tmp/.tmps4mQGN/redis-enterprise/src/services.rs:68
  struct redis_enterprise::bdb::BackupResponse, previously in file /tmp/.tmps4mQGN/redis-enterprise/src/bdb.rs:97
  struct redis_enterprise::usage_report::UsageReportConfig, previously in file /tmp/.tmps4mQGN/redis-enterprise/src/usage_report.rs:91
  struct redis_enterprise::UsageReportConfig, previously in file /tmp/.tmps4mQGN/redis-enterprise/src/usage_report.rs:91

--- failure struct_pub_field_missing: pub struct's pub field removed or renamed ---

Description:
A publicly-visible struct has at least one public field that is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.47.0/src/lints/struct_pub_field_missing.ron

Failed in:
  field status of struct BootstrapStatus, previously in file /tmp/.tmps4mQGN/redis-enterprise/src/bootstrap.rs:105
  field progress of struct BootstrapStatus, previously in file /tmp/.tmps4mQGN/redis-enterprise/src/bootstrap.rs:108
  field message of struct BootstrapStatus, previously in file /tmp/.tmps4mQGN/redis-enterprise/src/bootstrap.rs:111
  field status of struct BootstrapStatus, previously in file /tmp/.tmps4mQGN/redis-enterprise/src/bootstrap.rs:105
  field progress of struct BootstrapStatus, previously in file /tmp/.tmps4mQGN/redis-enterprise/src/bootstrap.rs:108
  field message of struct BootstrapStatus, previously in file /tmp/.tmps4mQGN/redis-enterprise/src/bootstrap.rs:111
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.9.0](https://github.com/redis-developer/redis-enterprise-rs/compare/v0.8.7...v0.9.0) - 2026-05-26

### Added

- *(modules)* add user-defined module management endpoints ([#90](https://github.com/redis-developer/redis-enterprise-rs/pull/90))
- *(cluster)* add SSO and SAML metadata endpoints ([#89](https://github.com/redis-developer/redis-enterprise-rs/pull/89))
- *(crdb)* add flush, health_report, purge, and updates endpoints ([#88](https://github.com/redis-developer/redis-enterprise-rs/pull/88))
- *(cluster)* add change_password_hashing_algorithm endpoint ([#87](https://github.com/redis-developer/redis-enterprise-rs/pull/87))
- *(cluster, nodes, users)* add check() endpoints and RBAC-friendly user role/role_uids ([#72](https://github.com/redis-developer/redis-enterprise-rs/pull/72))

### Fixed

- *(alerts)* list_cluster_alerts returns HashMap<String, ClusterAlertState> ([#83](https://github.com/redis-developer/redis-enterprise-rs/pull/83))
- *(bootstrap)* reshape status response to match the documented spec wrapper ([#82](https://github.com/redis-developer/redis-enterprise-rs/pull/82))
- *(types)* unwrap {crdbs} / {bdb_groups} wrappers on list endpoints ([#81](https://github.com/redis-developer/redis-enterprise-rs/pull/81))
- *(proxies)* make optional fields Optional and widen maxmemory_clients to u64 ([#80](https://github.com/redis-developer/redis-enterprise-rs/pull/80))
- *(actions)* correctly decode the {actions, state-machines} wrapper; string-typed progress/node_uid ([#79](https://github.com/redis-developer/redis-enterprise-rs/pull/79))
- *(builder)* reject missing credentials ([#44](https://github.com/redis-developer/redis-enterprise-rs/pull/44))
- *(ocsp)* test() uses POST (the documented verb), not GET ([#78](https://github.com/redis-developer/redis-enterprise-rs/pull/78))
- *(nodes)* execute_action POSTs to /v1/nodes/{uid}/actions/{action}, the documented path ([#77](https://github.com/redis-developer/redis-enterprise-rs/pull/77))
- *(bdb)* flush() and reset_admin_pass() use the documented PUT path-segment endpoints ([#76](https://github.com/redis-developer/redis-enterprise-rs/pull/76))
- *(crdb)* UPDATE uses PATCH verb (the documented one), not PUT ([#75](https://github.com/redis-developer/redis-enterprise-rs/pull/75))
- *(stats, crdb_tasks)* handle real-API response shapes and use the documented action endpoints ([#71](https://github.com/redis-developer/redis-enterprise-rs/pull/71))

### Other

- README + examples refresh for v0.9.0 ([#96](https://github.com/redis-developer/redis-enterprise-rs/pull/96))
- remove fictional services / jsonschema / usage_report routes ([#95](https://github.com/redis-developer/redis-enterprise-rs/pull/95))
- *(bdb)* remove fictional actions/{backup,restore,upgrade} ([#94](https://github.com/redis-developer/redis-enterprise-rs/pull/94))
- *(alerts)* remove fictional /v1/alerts* top-level routes ([#93](https://github.com/redis-developer/redis-enterprise-rs/pull/93))
- *(audit)* per-route triage for the 122 non-spec SDK routes ([#92](https://github.com/redis-developer/redis-enterprise-rs/pull/92))
- *(live-validation)* add TLS, licensing, and teardown sections; link from README ([#91](https://github.com/redis-developer/redis-enterprise-rs/pull/91))
- enforce #![deny(missing_docs)] and rustdoc::broken_intra_doc_links ([#86](https://github.com/redis-developer/redis-enterprise-rs/pull/86))
- *(missing-docs)* document fields and enum variants across the crate ([#85](https://github.com/redis-developer/redis-enterprise-rs/pull/85))
- *(coverage)* add route-coverage test against the docs API inventory ([#84](https://github.com/redis-developer/redis-enterprise-rs/pull/84))
- update dependency versions ([#46](https://github.com/redis-developer/redis-enterprise-rs/pull/46))
- *(env)* document CA cert variable ([#45](https://github.com/redis-developer/redis-enterprise-rs/pull/45))
- *(live)* add opt-in live integration smoke tests against a real Redis Enterprise cluster ([#74](https://github.com/redis-developer/redis-enterprise-rs/pull/74))
- *(infra)* add API audit docs + scripts and modernize docker-compose ([#70](https://github.com/redis-developer/redis-enterprise-rs/pull/70))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).