### PR TITLE
fix(crdb): UPDATE uses PATCH verb (the documented one), not PUT

### DIFF
--- a/src/crdb.rs
+++ b/src/crdb.rs
@@ -145,11 +145,18 @@ impl CrdbHandler {
         self.client.post("/v1/crdbs", &request).await
     }
 
-    /// Update CRDB
+    /// Update an existing CRDB.
+    ///
+    /// `PATCH /v1/crdbs/{crdb_guid}`. The Redis Enterprise REST API
+    /// documents the CRDB update verb as `PATCH`; the previous
+    /// implementation used `PUT` and returned 405 on recent cluster
+    /// versions.
     pub async fn update(&self, guid: &str, updates: Value) -> Result<Crdb> {
-        self.client
-            .put(&format!("/v1/crdbs/{}", guid), &updates)
-            .await
+        let response = self
+            .client
+            .patch_raw(&format!("/v1/crdbs/{}", guid), updates)
+            .await?;
+        serde_json::from_value(response).map_err(Into::into)
     }
 
     /// Delete CRDB

--- a/tests/crdb_tests.rs
+++ b/tests/crdb_tests.rs
@@ -387,7 +387,7 @@ async fn test_crdb_update() {
         "eviction_policy": "volatile-lru"
     });
 
-    Mock::given(method("PUT"))
+    Mock::given(method("PATCH"))
         .and(path("/v1/crdbs/12345-abcdef-67890"))
         .and(basic_auth("admin", "password"))
         .and(body_json(&updates))
@@ -430,7 +430,7 @@ async fn test_crdb_update_nonexistent() {
         "memory_size": 2147483648u64
     });
 
-    Mock::given(method("PUT"))
+    Mock::given(method("PATCH"))
         .and(path("/v1/crdbs/nonexistent-guid"))
         .and(basic_auth("admin", "password"))
         .and(body_json(&updates))


### PR DESCRIPTION
## Summary

`CrdbHandler::update` previously sent `PUT /v1/crdbs/{guid}`, returning 405 Method Not Allowed on recent cluster versions. The Redis Enterprise REST API [documents the verb as PATCH](https://redis.io/docs/latest/operate/rs/references/rest-api/requests/crdbs/).

This PR switches the verb to PATCH using the existing `client.patch_raw` method and deserializes the response into `Crdb`. The two existing wiremock tests now match on `PATCH`.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace` — all pass

Closes #58