### PR TITLE
fix(bdb): flush() and reset_admin_pass() use the documented PUT path-segment endpoints

### DIFF
--- a/src/bdb.rs
+++ b/src/bdb.rs
@@ -609,14 +609,17 @@ impl DatabaseHandler {
             .await
     }
 
-    /// Flush database (BDB.FLUSH)
+    /// Flush all keys from a database.
+    ///
+    /// `PUT /v1/bdbs/{uid}/flush`. This is the path-segment-style action
+    /// the REST API documents; the previous implementation POSTed to
+    /// `/v1/bdbs/{uid}/actions/flush`, which is not in the spec.
     pub async fn flush(&self, uid: u32) -> Result<DatabaseActionResponse> {
-        self.client
-            .post(
-                &format!("/v1/bdbs/{}/actions/flush", uid),
-                &serde_json::json!({}),
-            )
-            .await
+        let response = self
+            .client
+            .put_raw(&format!("/v1/bdbs/{}/flush", uid), serde_json::json!({}))
+            .await?;
+        serde_json::from_value(response).map_err(Into::into)
     }
 
     /// Backup database (BDB.BACKUP)
@@ -960,8 +963,12 @@ impl DatabaseHandler {
             .await
     }
 
-    /// Reset database password (BDB.RESET_PASSWORD)
-    pub async fn reset_password(
+    /// Reset the database admin password.
+    ///
+    /// `PUT /v1/bdbs/{uid}/reset_admin_pass`. This is the path-segment-style
+    /// action the REST API documents. The new password is sent in the body
+    /// under the `authentication_redis_pass` key.
+    pub async fn reset_admin_pass(
         &self,
         uid: u32,
         new_password: &str,
@@ -969,9 +976,28 @@ impl DatabaseHandler {
         let body = serde_json::json!({
             "authentication_redis_pass": new_password
         });
-        self.client
-            .post(&format!("/v1/bdbs/{}/actions/reset_password", uid), &body)
-            .await
+        let response = self
+            .client
+            .put_raw(&format!("/v1/bdbs/{}/reset_admin_pass", uid), body)
+            .await?;
+        serde_json::from_value(response).map_err(Into::into)
+    }
+
+    /// Reset database password.
+    ///
+    /// Deprecated alias for [`Self::reset_admin_pass`]. The previous
+    /// implementation POSTed to `/v1/bdbs/{uid}/actions/reset_password`,
+    /// which is not in the REST API spec.
+    #[deprecated(
+        since = "0.9.0",
+        note = "use `reset_admin_pass`; the action POST path was not in the REST API spec"
+    )]
+    pub async fn reset_password(
+        &self,
+        uid: u32,
+        new_password: &str,
+    ) -> Result<DatabaseActionResponse> {
+        self.reset_admin_pass(uid, new_password).await
     }
 
     /// Check database availability

--- a/tests/bdb/actions.rs
+++ b/tests/bdb/actions.rs
@@ -172,3 +172,61 @@ async fn test_database_upgrade_redis_version() {
     let response = result.unwrap();
     assert_eq!(response.action_uid, "591d9dcb-ddd7-48a9-a04d-bd5d4d6834d0");
 }
+
+#[tokio::test]
+async fn test_database_flush_uses_put_path_segment() {
+    // Regression guard for #59: the documented verb/path is
+    // `PUT /v1/bdbs/{uid}/flush`, not `POST /v1/bdbs/{uid}/actions/flush`.
+    let mock_server = MockServer::start().await;
+
+    Mock::given(method("PUT"))
+        .and(path("/v1/bdbs/1/flush"))
+        .and(basic_auth("admin", "password"))
+        .respond_with(success_response(json!({"action_uid": "flush-action-1"})))
+        .mount(&mock_server)
+        .await;
+
+    let client = test_client(&mock_server);
+    let result = client.databases().flush(1).await;
+    assert!(result.is_ok());
+    assert_eq!(result.unwrap().action_uid, "flush-action-1");
+}
+
+#[tokio::test]
+async fn test_database_reset_admin_pass_uses_put_path_segment() {
+    // Regression guard for #59: `PUT /v1/bdbs/{uid}/reset_admin_pass`
+    // (path-segment) is the documented endpoint; the previous
+    // `POST /v1/bdbs/{uid}/actions/reset_password` was not in the spec.
+    let mock_server = MockServer::start().await;
+
+    Mock::given(method("PUT"))
+        .and(path("/v1/bdbs/1/reset_admin_pass"))
+        .and(basic_auth("admin", "password"))
+        .respond_with(success_response(json!({"action_uid": "reset-action-1"})))
+        .mount(&mock_server)
+        .await;
+
+    let client = test_client(&mock_server);
+    let result = client.databases().reset_admin_pass(1, "new-pass-123").await;
+    assert!(result.is_ok());
+    assert_eq!(result.unwrap().action_uid, "reset-action-1");
+}
+
+#[tokio::test]
+#[allow(deprecated)]
+async fn test_database_reset_password_deprecated_alias_routes_through_new_path() {
+    // `reset_password` is kept as a deprecated alias for `reset_admin_pass`
+    // and must hit the same documented endpoint, not the legacy action path.
+    let mock_server = MockServer::start().await;
+
+    Mock::given(method("PUT"))
+        .and(path("/v1/bdbs/1/reset_admin_pass"))
+        .and(basic_auth("admin", "password"))
+        .respond_with(success_response(json!({"action_uid": "reset-action-1"})))
+        .mount(&mock_server)
+        .await;
+
+    let client = test_client(&mock_server);
+    let result = client.databases().reset_password(1, "new-pass-123").await;
+    assert!(result.is_ok());
+}


### PR DESCRIPTION
## Summary

The Redis Enterprise REST API documents two BDB action endpoints in path-segment style:

- `PUT /v1/bdbs/{uid}/flush` — clear all keys
- `PUT /v1/bdbs/{uid}/reset_admin_pass` — reset the admin password

The previous implementation used `POST /v1/bdbs/{uid}/actions/flush` and `POST /v1/bdbs/{uid}/actions/reset_password`. Neither path is in the spec; both produce 404/405 against modern clusters.

## Changes

| Before | After |
|---|---|
| `POST /v1/bdbs/{uid}/actions/flush` | `PUT /v1/bdbs/{uid}/flush` |
| `POST /v1/bdbs/{uid}/actions/reset_password` | `PUT /v1/bdbs/{uid}/reset_admin_pass` (new method) |
| — | `reset_password` kept as `#[deprecated]` alias forwarding to `reset_admin_pass` |

## Tests added

- `test_database_flush_uses_put_path_segment`
- `test_database_reset_admin_pass_uses_put_path_segment`
- `test_database_reset_password_deprecated_alias_routes_through_new_path`

All wiremock-assert the exact outbound verb + path.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace` — all pass

Closes #59
Refs #65 (broader non-spec routes audit — `backup`/`restore`/etc. on bdb still TBD)