### PR TITLE
fix(nodes): execute_action POSTs to /v1/nodes/{uid}/actions/{action}, the documented path

### DIFF
--- a/src/nodes.rs
+++ b/src/nodes.rs
@@ -195,15 +195,25 @@ impl NodeHandler {
         self.client.get(&format!("/v1/nodes/{}/actions", uid)).await
     }
 
-    /// Execute node action (e.g., "maintenance_on", "maintenance_off")
+    /// Execute a named node action (e.g. `"maintenance_on"`, `"maintenance_off"`).
+    ///
+    /// `POST /v1/nodes/{uid}/actions/{action}`. The previous implementation
+    /// POSTed to `/v1/nodes/{uid}/actions` with the action name in the body
+    /// — that endpoint is the GET-list URL, and the action name was
+    /// effectively dropped on the wire, so this method did not work
+    /// against real clusters.
+    ///
+    /// Callers that need to send a custom JSON body (e.g. action-specific
+    /// parameters) should use [`Self::action_execute`] directly.
     pub async fn execute_action(&self, uid: u32, action: &str) -> Result<NodeActionResponse> {
-        let request = NodeActionRequest {
-            action: action.to_string(),
-            node_uid: Some(uid),
-        };
-        self.client
-            .post(&format!("/v1/nodes/{}/actions", uid), &request)
-            .await
+        let response: Value = self
+            .client
+            .post(
+                &format!("/v1/nodes/{}/actions/{}", uid, action),
+                &serde_json::json!({}),
+            )
+            .await?;
+        serde_json::from_value(response).map_err(Into::into)
     }
 
     // raw variant removed in favor of typed execute_action

--- a/tests/node_tests.rs
+++ b/tests/node_tests.rs
@@ -557,15 +557,13 @@ async fn test_node_actions_nonexistent() {
 async fn test_node_execute_action_maintenance_on() {
     let mock_server = MockServer::start().await;
 
-    let expected_request = json!({
-        "action": "maintenance_on",
-        "node_uid": 1
-    });
-
+    // Regression guard for #60: action name lives in the URL path, not
+    // the body. Body is intentionally empty so the verb + path is the
+    // sole assertion.
     Mock::given(method("POST"))
-        .and(path("/v1/nodes/1/actions"))
+        .and(path("/v1/nodes/1/actions/maintenance_on"))
         .and(basic_auth("admin", "password"))
-        .and(body_json(&expected_request))
+        .and(body_json(json!({})))
         .respond_with(success_response(json!({
             "action_uid": "action-123-abc",
             "status": "pending",
@@ -590,15 +588,10 @@ async fn test_node_execute_action_maintenance_on() {
 async fn test_node_execute_action_maintenance_off() {
     let mock_server = MockServer::start().await;
 
-    let expected_request = json!({
-        "action": "maintenance_off",
-        "node_uid": 1
-    });
-
     Mock::given(method("POST"))
-        .and(path("/v1/nodes/1/actions"))
+        .and(path("/v1/nodes/1/actions/maintenance_off"))
         .and(basic_auth("admin", "password"))
-        .and(body_json(&expected_request))
+        .and(body_json(json!({})))
         .respond_with(success_response(json!({
             "action_uid": "action-456-def",
             "status": "completed",
@@ -623,15 +616,10 @@ async fn test_node_execute_action_maintenance_off() {
 async fn test_node_execute_action_invalid() {
     let mock_server = MockServer::start().await;
 
-    let expected_request = json!({
-        "action": "invalid_action",
-        "node_uid": 1
-    });
-
     Mock::given(method("POST"))
-        .and(path("/v1/nodes/1/actions"))
+        .and(path("/v1/nodes/1/actions/invalid_action"))
         .and(basic_auth("admin", "password"))
-        .and(body_json(&expected_request))
+        .and(body_json(json!({})))
         .respond_with(error_response(400, "Invalid action"))
         .mount(&mock_server)
         .await;
@@ -653,15 +641,10 @@ async fn test_node_execute_action_invalid() {
 async fn test_node_execute_action_nonexistent_node() {
     let mock_server = MockServer::start().await;
 
-    let expected_request = json!({
-        "action": "restart",
-        "node_uid": 999
-    });
-
     Mock::given(method("POST"))
-        .and(path("/v1/nodes/999/actions"))
+        .and(path("/v1/nodes/999/actions/restart"))
         .and(basic_auth("admin", "password"))
-        .and(body_json(&expected_request))
+        .and(body_json(json!({})))
         .respond_with(error_response(404, "Node not found"))
         .mount(&mock_server)
         .await;


### PR DESCRIPTION
## Summary

`NodeHandler::execute_action` previously POSTed to `/v1/nodes/{uid}/actions` (the GET-list URL) with the action name in the body. That dropped the action name on the wire — calls like `maintenance_on`/`maintenance_off` didn't work against real clusters.

This PR fixes the verb + path to the documented `POST /v1/nodes/{uid}/actions/{action}` with an empty body.

## What's not changed

`NodeHandler::action_execute(uid, action, body)` already POSTs to the correct path and accepts a custom body. It's left as the entry point for callers who need to send action-specific parameters.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace` — all pass
- [x] Four existing tests (`test_node_execute_action_*`) updated to assert the documented path + empty body. They previously asserted the broken behavior.

Closes #60