### PR TITLE
fix(ocsp): test() uses POST (the documented verb), not GET

### DIFF
--- a/src/ocsp.rs
+++ b/src/ocsp.rs
@@ -92,16 +92,25 @@ impl OcspHandler {
         self.client.get("/v1/ocsp/status").await
     }
 
-    /// Test OCSP connectivity
+    /// Test OCSP connectivity.
+    ///
+    /// `POST /v1/ocsp/test`. The REST API documents this verb as POST;
+    /// the previous implementation used GET, which is not in the spec
+    /// and returns 404/405 against modern clusters.
     pub async fn test(&self) -> Result<OcspTestResult> {
-        self.client.get("/v1/ocsp/test").await
-    }
-
-    /// Test OCSP via POST
-    pub async fn test_post(&self) -> Result<OcspTestResult> {
         self.client
             .post("/v1/ocsp/test", &serde_json::Value::Null)
             .await
+    }
+
+    /// Test OCSP via POST. Deprecated alias for [`Self::test`], which now
+    /// uses POST itself per the documented verb.
+    #[deprecated(
+        since = "0.9.0",
+        note = "use `test`; `test` now uses POST per the spec"
+    )]
+    pub async fn test_post(&self) -> Result<OcspTestResult> {
+        self.test().await
     }
 
     /// Trigger OCSP query

--- a/tests/ocsp_tests.rs
+++ b/tests/ocsp_tests.rs
@@ -341,7 +341,7 @@ async fn test_ocsp_get_status_not_configured() {
 async fn test_ocsp_test_success() {
     let mock_server = MockServer::start().await;
 
-    Mock::given(method("GET"))
+    Mock::given(method("POST"))
         .and(path("/v1/ocsp/test"))
         .and(basic_auth("admin", "password"))
         .respond_with(success_response(test_ocsp_test_result_success()))
@@ -372,7 +372,7 @@ async fn test_ocsp_test_success() {
 async fn test_ocsp_test_failure() {
     let mock_server = MockServer::start().await;
 
-    Mock::given(method("GET"))
+    Mock::given(method("POST"))
         .and(path("/v1/ocsp/test"))
         .and(basic_auth("admin", "password"))
         .respond_with(success_response(test_ocsp_test_result_failure()))
@@ -403,7 +403,7 @@ async fn test_ocsp_test_failure() {
 async fn test_ocsp_test_not_configured() {
     let mock_server = MockServer::start().await;
 
-    Mock::given(method("GET"))
+    Mock::given(method("POST"))
         .and(path("/v1/ocsp/test"))
         .and(basic_auth("admin", "password"))
         .respond_with(error_response(400, "OCSP not enabled"))


### PR DESCRIPTION
## Summary

`OcspHandler::test` previously used GET, but the REST API documents this endpoint as `POST /v1/ocsp/test`. A second method, `test_post`, did it correctly but is awkwardly named.

## Changes

- `test()` now POSTs (using the same call `test_post` used).
- `test_post` kept as `#[deprecated]` alias forwarding to `test`, so callers working around the bug continue to compile during one release cycle.
- Three existing tests (`test_ocsp_test_success`, `test_ocsp_test_failure`, `test_ocsp_test_not_configured`) updated to match on POST; they previously asserted the broken GET behavior.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace` — all pass

Closes #61