### PR TITLE
fix(actions): correctly decode the {actions, state-machines} wrapper; string-typed progress/node_uid

### DIFF
--- a/src/actions.rs
+++ b/src/actions.rs
@@ -9,32 +9,82 @@ use crate::client::RestClient;
 use crate::error::Result;
 use serde::{Deserialize, Serialize};
 
-/// Action information
-/// Represents an action (operation) in the cluster
+/// Action information.
+///
+/// Represents an action (or state machine) in the cluster. The
+/// `GET /v1/actions` endpoint returns a wrapper with two arrays —
+/// `actions` and `state-machines` — that share most fields; this
+/// struct accepts both shapes with everything outside the common
+/// `(action_uid, name, status)` core typed as `Option`.
+///
+/// Fields like `progress`, `node_uid`, `task_id`, and `creation_time`
+/// are typed `Option<String>` because the real API returns them as
+/// strings (e.g. `"progress": "100"`, `"node_uid": "1"`), not numbers
+/// — the previous numeric typing decode-failed on every real response.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Action {
-    /// Action's unique identifier (read-only)
+    /// Action's unique identifier (read-only).
     pub action_uid: String,
-    /// Action's name (read-only)
+    /// Action's name (read-only).
     pub name: String,
-    /// Current status of the action
+    /// Current status of the action.
     ///
-    /// Possible values: 'queued', 'starting', 'running', 'cancelling', 'cancelled', 'completed', 'failed'
+    /// Possible values: `queued`, `starting`, `running`, `cancelling`,
+    /// `cancelled`, `completed`, `failed`.
     pub status: String,
-    /// Percent of completed steps in current action (0-100)
-    pub progress: Option<f32>,
-    /// ISO 8601 timestamp when the action was started
+    /// Percent of completed steps (0–100). Wire type is `string`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub progress: Option<String>,
+    /// ISO 8601 timestamp when the action was started.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub start_time: Option<String>,
-    /// ISO 8601 timestamp when the action completed or failed
+    /// ISO 8601 timestamp when the action completed or failed.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub end_time: Option<String>,
-    /// Human-readable description of the action
+    /// Unix-epoch (or ISO-8601) timestamp when the action was created.
+    /// Present on entries in the `actions` array.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub creation_time: Option<String>,
+    /// Task ID associated with the action. Wire type is `string`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub task_id: Option<String>,
+    /// Heartbeat timestamp (Unix seconds). Present on entries in the
+    /// `state-machines` array.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub heartbeat: Option<i64>,
+    /// Resource the state machine acts on (e.g. `"bdb:1"`). Present on
+    /// entries in the `state-machines` array.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub object_name: Option<String>,
+    /// Human-readable description of the action.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
-    /// Error message if the action failed
+    /// Error message if the action failed.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub error: Option<String>,
-    /// Database UID associated with the action
+    /// Database UID associated with the action.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub bdb_uid: Option<u32>,
-    /// Node UID associated with the action
-    pub node_uid: Option<u32>,
+    /// Node UID associated with the action. Wire type is `string`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub node_uid: Option<String>,
+}
+
+/// Response wrapper for `GET /v1/actions`.
+///
+/// The Redis Enterprise API returns
+/// `{ "actions": [...], "state-machines": [...] }`. Use
+/// [`ActionHandler::list_response`] to get the typed wrapper, or
+/// [`ActionHandler::list`] for a single flat `Vec<Action>` combining
+/// both arrays.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ActionsListResponse {
+    /// Active and recently completed actions.
+    #[serde(default)]
+    pub actions: Vec<Action>,
+    /// Long-running state machines (e.g. SMCreateBDB).
+    #[serde(default, rename = "state-machines")]
+    pub state_machines: Vec<Action>,
 }
 
 /// Action handler for tracking async operations
@@ -48,8 +98,24 @@ impl ActionHandler {
         ActionHandler { client }
     }
 
-    /// List all actions
+    /// List all actions and state machines, flattened into a single vector.
+    ///
+    /// `GET /v1/actions`. The API returns `{actions, state-machines}`;
+    /// this method unwraps the wrapper and concatenates both arrays.
+    /// Use [`Self::list_response`] if you need them separated.
     pub async fn list(&self) -> Result<Vec<Action>> {
+        let resp: ActionsListResponse = self.client.get("/v1/actions").await?;
+        let mut combined = resp.actions;
+        combined.extend(resp.state_machines);
+        Ok(combined)
+    }
+
+    /// List all actions and state machines as the spec-shaped wrapper.
+    ///
+    /// `GET /v1/actions`. Returns the `{actions, state-machines}`
+    /// response shape unchanged for callers that need to distinguish
+    /// the two arrays.
+    pub async fn list_response(&self) -> Result<ActionsListResponse> {
         self.client.get("/v1/actions").await
     }
 
@@ -79,11 +145,19 @@ impl ActionHandler {
             .await
     }
 
-    /// List actions for a database - GET /v1/actions/bdb/{uid}
+    /// List actions for a single database.
+    ///
+    /// `GET /v1/actions/bdb/{uid}`. Returns the same
+    /// `{actions, state-machines}` wrapper as the top-level
+    /// `GET /v1/actions`; the two arrays are concatenated.
     pub async fn list_for_bdb(&self, bdb_uid: u32) -> Result<Vec<Action>> {
-        self.client
+        let resp: ActionsListResponse = self
+            .client
             .get(&format!("/v1/actions/bdb/{}", bdb_uid))
-            .await
+            .await?;
+        let mut combined = resp.actions;
+        combined.extend(resp.state_machines);
+        Ok(combined)
     }
 
     // Versioned sub-handlers for clearer API
@@ -97,9 +171,10 @@ impl ActionHandler {
 }
 
 pub mod v1 {
-    use super::{Action, RestClient};
+    use super::{Action, ActionsListResponse, RestClient};
     use crate::error::Result;
 
+    /// V1 sub-handler for `/v1/actions` endpoints.
     pub struct ActionsV1 {
         client: RestClient,
     }
@@ -109,26 +184,37 @@ pub mod v1 {
             Self { client }
         }
 
+        /// List actions + state machines, flattened.
         pub async fn list(&self) -> Result<Vec<Action>> {
-            self.client.get("/v1/actions").await
+            let resp: ActionsListResponse = self.client.get("/v1/actions").await?;
+            let mut combined = resp.actions;
+            combined.extend(resp.state_machines);
+            Ok(combined)
         }
 
+        /// Get a single action by UID.
         pub async fn get(&self, action_uid: &str) -> Result<Action> {
             self.client
                 .get(&format!("/v1/actions/{}", action_uid))
                 .await
         }
 
+        /// Cancel an in-flight action.
         pub async fn cancel(&self, action_uid: &str) -> Result<()> {
             self.client
                 .delete(&format!("/v1/actions/{}", action_uid))
                 .await
         }
 
+        /// List actions + state machines scoped to a single database, flattened.
         pub async fn list_for_bdb(&self, bdb_uid: u32) -> Result<Vec<Action>> {
-            self.client
+            let resp: ActionsListResponse = self
+                .client
                 .get(&format!("/v1/actions/bdb/{}", bdb_uid))
-                .await
+                .await?;
+            let mut combined = resp.actions;
+            combined.extend(resp.state_machines);
+            Ok(combined)
         }
     }
 }

--- a/tests/action_tests.rs
+++ b/tests/action_tests.rs
@@ -15,11 +15,13 @@ fn no_content_response() -> ResponseTemplate {
 }
 
 fn test_action() -> serde_json::Value {
+    // Note: real API returns progress as a string, not a number — the
+    // type matches what `cat tests/fixtures/actions_list.json` shows.
     json!({
         "action_uid": "action-123-abc",
         "name": "database_backup",
         "status": "running",
-        "progress": 45.5,
+        "progress": "45",
         "start_time": "2023-01-01T12:00:00Z",
         "end_time": null,
         "description": "Backing up database test-db",
@@ -32,7 +34,7 @@ fn completed_action() -> serde_json::Value {
         "action_uid": "action-456-def",
         "name": "database_restore",
         "status": "completed",
-        "progress": 100.0,
+        "progress": "100",
         "start_time": "2023-01-01T11:00:00Z",
         "end_time": "2023-01-01T11:30:00Z",
         "description": "Restored database from backup",
@@ -45,7 +47,7 @@ fn failed_action() -> serde_json::Value {
         "action_uid": "action-789-ghi",
         "name": "node_add",
         "status": "failed",
-        "progress": 25.0,
+        "progress": "25",
         "start_time": "2023-01-01T10:00:00Z",
         "end_time": "2023-01-01T10:15:00Z",
         "description": "Adding new node to cluster",
@@ -57,14 +59,19 @@ fn failed_action() -> serde_json::Value {
 async fn test_action_list() {
     let mock_server = MockServer::start().await;
 
+    // Regression guard for #62: real API returns the wrapper shape
+    // `{actions: [...], state-machines: [...]}`, not a bare array.
     Mock::given(method("GET"))
         .and(path("/v1/actions"))
         .and(basic_auth("admin", "password"))
-        .respond_with(success_response(json!([
-            test_action(),
-            completed_action(),
-            failed_action()
-        ])))
+        .respond_with(success_response(json!({
+            "actions": [
+                test_action(),
+                completed_action(),
+                failed_action()
+            ],
+            "state-machines": []
+        })))
         .mount(&mock_server)
         .await;
 
@@ -87,7 +94,8 @@ async fn test_action_list() {
     assert_eq!(running_action.action_uid, "action-123-abc");
     assert_eq!(running_action.name, "database_backup");
     assert_eq!(running_action.status, "running");
-    assert_eq!(running_action.progress, Some(45.5));
+    // Regression guard for #63: progress is a string on the wire.
+    assert_eq!(running_action.progress.as_deref(), Some("45"));
     assert!(running_action.end_time.is_none());
     assert!(running_action.error.is_none());
 }
@@ -96,10 +104,14 @@ async fn test_action_list() {
 async fn test_action_list_empty() {
     let mock_server = MockServer::start().await;
 
+    // Empty case: API returns the wrapper with both arrays empty.
     Mock::given(method("GET"))
         .and(path("/v1/actions"))
         .and(basic_auth("admin", "password"))
-        .respond_with(success_response(json!([])))
+        .respond_with(success_response(json!({
+            "actions": [],
+            "state-machines": []
+        })))
         .mount(&mock_server)
         .await;
 
@@ -144,7 +156,7 @@ async fn test_action_get_running() {
     assert_eq!(action.action_uid, "action-123-abc");
     assert_eq!(action.name, "database_backup");
     assert_eq!(action.status, "running");
-    assert_eq!(action.progress, Some(45.5));
+    assert_eq!(action.progress.as_deref(), Some("45"));
     assert_eq!(
         action.description,
         Some("Backing up database test-db".to_string())
@@ -178,7 +190,7 @@ async fn test_action_get_completed() {
     let action = result.unwrap();
     assert_eq!(action.action_uid, "action-456-def");
     assert_eq!(action.status, "completed");
-    assert_eq!(action.progress, Some(100.0));
+    assert_eq!(action.progress.as_deref(), Some("100"));
     assert!(action.end_time.is_some());
     assert!(action.error.is_none());
 }
@@ -208,7 +220,7 @@ async fn test_action_get_failed() {
     let action = result.unwrap();
     assert_eq!(action.action_uid, "action-789-ghi");
     assert_eq!(action.status, "failed");
-    assert_eq!(action.progress, Some(25.0));
+    assert_eq!(action.progress.as_deref(), Some("25"));
     assert_eq!(
         action.error,
         Some("Connection timeout to new node".to_string())
@@ -290,4 +302,71 @@ async fn test_action_get_nonexistent() {
     let result = handler.get("nonexistent-action").await;
 
     assert!(result.is_err());
+}
+
+#[tokio::test]
+async fn test_action_list_state_machines_combined_into_flat_vec() {
+    // Regression guard for #62 + #63: the wrapper carries both arrays,
+    // shapes diverge between them (state-machines use heartbeat: i64,
+    // object_name: String; actions use creation_time / task_id /
+    // string-typed progress + node_uid).
+    let mock_server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/v1/actions"))
+        .and(basic_auth("admin", "password"))
+        .respond_with(success_response(json!({
+            "actions": [
+                {
+                    "action_uid": "8fc32a11-4688-4057-9237-cd77fccd726f",
+                    "creation_time": "1760400087",
+                    "name": "retry_bdb",
+                    "node_uid": "1",
+                    "progress": "100",
+                    "status": "completed",
+                    "task_id": "8fc32a11-4688-4057-9237-cd77fccd726f"
+                }
+            ],
+            "state-machines": [
+                {
+                    "action_uid": "04d7b6ea-f377-4d40-9b23-9a8f291988df",
+                    "heartbeat": 1760400082,
+                    "name": "SMCreateBDB",
+                    "object_name": "bdb:1",
+                    "status": "completed"
+                }
+            ]
+        })))
+        .mount(&mock_server)
+        .await;
+
+    let client = EnterpriseClient::builder()
+        .base_url(mock_server.uri())
+        .username("admin")
+        .password("password")
+        .build()
+        .unwrap();
+
+    let handler = ActionHandler::new(client);
+
+    // Flat view: actions first, state machines appended.
+    let actions = handler.list().await.unwrap();
+    assert_eq!(actions.len(), 2);
+
+    let action_entry = &actions[0];
+    assert_eq!(action_entry.name, "retry_bdb");
+    assert_eq!(action_entry.progress.as_deref(), Some("100"));
+    assert_eq!(action_entry.node_uid.as_deref(), Some("1"));
+    assert_eq!(action_entry.creation_time.as_deref(), Some("1760400087"));
+    assert!(action_entry.task_id.is_some());
+
+    let sm_entry = &actions[1];
+    assert_eq!(sm_entry.name, "SMCreateBDB");
+    assert_eq!(sm_entry.heartbeat, Some(1760400082));
+    assert_eq!(sm_entry.object_name.as_deref(), Some("bdb:1"));
+
+    // list_response gives the spec-shaped wrapper directly.
+    let wrapped = handler.list_response().await.unwrap();
+    assert_eq!(wrapped.actions.len(), 1);
+    assert_eq!(wrapped.state_machines.len(), 1);
 }


### PR DESCRIPTION
## Summary

Two coupled correctness fixes; both verified against `tests/fixtures/actions_list.json`.

### #62 — wrapper-decode for `GET /v1/actions`

`list()` and `list_for_bdb()` previously expected a bare `Vec<Action>`, but the API returns:

```json
{ "actions": [...], "state-machines": [...] }
```

Every real response decode-failed.

- New `ActionsListResponse { actions, state_machines }` models the spec shape.
- `list()` unwraps and concatenates both arrays into a flat `Vec<Action>`.
- New `list_response()` exposes the typed wrapper for callers that need them separated.
- `list_for_bdb()` and the `v1::ActionsV1` sub-handler get the same treatment.

### #63 — `Action` field types match the wire format

| Field | Before | After |
|---|---|---|
| `progress` | `Option<f32>` | `Option<String>` |
| `node_uid` | `Option<u32>` | `Option<String>` |
| `task_id` | _missing_ | `Option<String>` |
| `creation_time` | _missing_ | `Option<String>` |
| `heartbeat` | _missing_ | `Option<i64>` |
| `object_name` | _missing_ | `Option<String>` |

Added fields are `#[serde(default)]` so single-action GETs (which don't return the state-machine-specific fields) still deserialize.

## Tests

- Existing list/get tests updated to mount the wrapper shape and string-typed progress values (matching the real fixture).
- New `test_action_list_state_machines_combined_into_flat_vec` asserts the full wrapper flow with both arrays populated and verifies the typed `list_response()` API.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace` — all pass

Closes #63
Closes #62 (actions slice — wrapper-decode for crdb / bdb_groups / bootstrap / proxies / alerts ships separately)