### PR TITLE
fix(proxies): make optional fields Optional and widen maxmemory_clients to u64

### DIFF
--- a/src/proxies.rs
+++ b/src/proxies.rs
@@ -18,13 +18,28 @@ pub struct MetricResponse {
     pub values: Vec<Value>,
 }
 
-/// Proxy information
+/// Proxy information.
+///
+/// `GET /v1/proxies` returns both global proxy configuration entries
+/// (no `bdb_uid`/`node_uid`) and per-database proxies, so the fields
+/// that distinguish the two are `Option`. `maxmemory_clients` is `u64`
+/// because real clusters report values that exceed `u32::MAX` (the
+/// recorded fixture has `4_294_967_296`).
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Proxy {
+    /// Cluster-unique ID of the proxy.
     pub uid: u32,
-    pub bdb_uid: u32,
-    pub node_uid: u32,
-    pub status: String,
+    /// Database UID this proxy serves, if any. Absent on global proxy
+    /// configuration entries.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub bdb_uid: Option<u32>,
+    /// Node UID this proxy runs on, if any. Absent on global proxy
+    /// configuration entries.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub node_uid: Option<u32>,
+    /// Current proxy status (e.g. `"active"`, `"deactivated"`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub status: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub addr: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -119,9 +134,13 @@ pub struct Proxy {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub max_worker_txns: Option<u32>,
 
-    /// Maximum memory in bytes allocated for client connections
+    /// Maximum memory in bytes allocated for client connections.
+    ///
+    /// Typed as `u64` (not `u32`) because real clusters report values
+    /// that exceed `u32::MAX` — the recorded `tests/fixtures/proxies_list.json`
+    /// contains `4_294_967_296` (one byte over the `u32` ceiling).
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub maxmemory_clients: Option<u32>,
+    pub maxmemory_clients: Option<u64>,
 
     /// CPU usage threshold percentage for thread scaling decisions
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/tests/proxy_tests.rs
+++ b/tests/proxy_tests.rs
@@ -106,9 +106,9 @@ async fn test_proxy_list() {
     // Verify active proxy details
     let active = &proxies[0];
     assert_eq!(active.uid, 1);
-    assert_eq!(active.bdb_uid, 1);
-    assert_eq!(active.node_uid, 1);
-    assert_eq!(active.status, "active");
+    assert_eq!(active.bdb_uid, Some(1));
+    assert_eq!(active.node_uid, Some(1));
+    assert_eq!(active.status.as_deref(), Some("active"));
     assert_eq!(active.addr, Some("10.0.0.1".to_string()));
     assert_eq!(active.port, Some(12000));
     assert_eq!(active.max_connections, Some(1000));
@@ -117,15 +117,15 @@ async fn test_proxy_list() {
     // Verify standby proxy
     let standby = &proxies[1];
     assert_eq!(standby.uid, 2);
-    assert_eq!(standby.status, "standby");
+    assert_eq!(standby.status.as_deref(), Some("standby"));
     assert_eq!(standby.addr, Some("10.0.0.2".to_string()));
     assert_eq!(standby.port, Some(12001));
 
     // Verify minimal proxy (no optional fields)
     let minimal = &proxies[2];
     assert_eq!(minimal.uid, 3);
-    assert_eq!(minimal.bdb_uid, 2);
-    assert_eq!(minimal.status, "active");
+    assert_eq!(minimal.bdb_uid, Some(2));
+    assert_eq!(minimal.status.as_deref(), Some("active"));
     assert!(minimal.addr.is_none());
     assert!(minimal.port.is_none());
     assert!(minimal.max_connections.is_none());
@@ -182,9 +182,9 @@ async fn test_proxy_get() {
     assert!(result.is_ok());
     let proxy = result.unwrap();
     assert_eq!(proxy.uid, 1);
-    assert_eq!(proxy.bdb_uid, 1);
-    assert_eq!(proxy.node_uid, 1);
-    assert_eq!(proxy.status, "active");
+    assert_eq!(proxy.bdb_uid, Some(1));
+    assert_eq!(proxy.node_uid, Some(1));
+    assert_eq!(proxy.status.as_deref(), Some("active"));
     assert_eq!(proxy.addr, Some("10.0.0.1".to_string()));
     assert_eq!(proxy.port, Some(12000));
     assert_eq!(proxy.max_connections, Some(1000));
@@ -215,9 +215,9 @@ async fn test_proxy_get_minimal() {
     assert!(result.is_ok());
     let proxy = result.unwrap();
     assert_eq!(proxy.uid, 3);
-    assert_eq!(proxy.bdb_uid, 2);
-    assert_eq!(proxy.node_uid, 1);
-    assert_eq!(proxy.status, "active");
+    assert_eq!(proxy.bdb_uid, Some(2));
+    assert_eq!(proxy.node_uid, Some(1));
+    assert_eq!(proxy.status.as_deref(), Some("active"));
     assert!(proxy.addr.is_none());
     assert!(proxy.port.is_none());
 }
@@ -349,12 +349,12 @@ async fn test_proxy_list_by_database() {
     assert_eq!(proxies.len(), 2);
 
     // Both proxies should belong to database 1
-    assert_eq!(proxies[0].bdb_uid, 1);
-    assert_eq!(proxies[1].bdb_uid, 1);
+    assert_eq!(proxies[0].bdb_uid, Some(1));
+    assert_eq!(proxies[1].bdb_uid, Some(1));
 
     // Verify active and standby status
-    assert_eq!(proxies[0].status, "active");
-    assert_eq!(proxies[1].status, "standby");
+    assert_eq!(proxies[0].status.as_deref(), Some("active"));
+    assert_eq!(proxies[1].status.as_deref(), Some("standby"));
 }
 
 #[tokio::test]
@@ -409,12 +409,12 @@ async fn test_proxy_list_by_node() {
     assert_eq!(proxies.len(), 2);
 
     // Both proxies should be on node 1
-    assert_eq!(proxies[0].node_uid, 1);
-    assert_eq!(proxies[1].node_uid, 1);
+    assert_eq!(proxies[0].node_uid, Some(1));
+    assert_eq!(proxies[1].node_uid, Some(1));
 
     // Verify different databases
-    assert_eq!(proxies[0].bdb_uid, 1);
-    assert_eq!(proxies[1].bdb_uid, 2);
+    assert_eq!(proxies[0].bdb_uid, Some(1));
+    assert_eq!(proxies[1].bdb_uid, Some(2));
 }
 
 #[tokio::test]
@@ -570,4 +570,46 @@ async fn test_proxy_reload_nonexistent() {
     let result = handler.reload(999).await;
 
     assert!(result.is_err());
+}
+
+#[tokio::test]
+async fn test_proxy_list_global_config_fixture_decodes_with_u64_maxmemory_clients() {
+    // Regression guard for #64: the recorded fixture has
+    // maxmemory_clients = 4_294_967_296 (u32::MAX + 1), which used to
+    // overflow the u32-typed field. Also exercises the global proxy
+    // configuration shape where bdb_uid / node_uid / addr / status are
+    // absent.
+    let mock_server = MockServer::start().await;
+
+    let fixture: serde_json::Value =
+        serde_json::from_str(include_str!("fixtures/proxies_list.json"))
+            .expect("fixture should be valid JSON");
+
+    Mock::given(method("GET"))
+        .and(path("/v1/proxies"))
+        .and(basic_auth("admin", "password"))
+        .respond_with(success_response(fixture))
+        .mount(&mock_server)
+        .await;
+
+    let client = EnterpriseClient::builder()
+        .base_url(mock_server.uri())
+        .username("admin")
+        .password("password")
+        .build()
+        .unwrap();
+
+    let handler = ProxyHandler::new(client);
+    let proxies = handler.list().await.expect("fixture should decode");
+    assert_eq!(proxies.len(), 1);
+
+    let proxy = &proxies[0];
+    assert_eq!(proxy.uid, 1);
+    assert!(proxy.bdb_uid.is_none());
+    assert!(proxy.node_uid.is_none());
+    assert!(proxy.addr.is_none());
+    assert!(proxy.status.is_none());
+
+    // The u32-overflowing value comes through intact as u64.
+    assert_eq!(proxy.maxmemory_clients, Some(4_294_967_296));
 }


### PR DESCRIPTION
## Summary

The `Proxy` struct typed three fields as required that the real `GET /v1/proxies` response doesn't always include, plus one field that overflowed the chosen integer type on real clusters.

| Field | Before | After |
|---|---|---|
| `bdb_uid` | `u32` (required) | `Option<u32>` |
| `node_uid` | `u32` (required) | `Option<u32>` |
| `status` | `String` (required) | `Option<String>` |
| `maxmemory_clients` | `Option<u32>` | `Option<u64>` |

Why each change matters:

- `bdb_uid` / `node_uid` / `status` are absent on the global proxy configuration entry that `GET /v1/proxies` returns. The recorded fixture `tests/fixtures/proxies_list.json` is exactly this shape; the previous typing decode-failed on it.
- `maxmemory_clients` in the same fixture is `4_294_967_296` — `u32::MAX + 1`. Widening to `u64` lets the value through intact.

## Tests

- Existing assertions on `proxy.bdb_uid` / `node_uid` (now wrapped in `Some(_)`) and `proxy.status` / `.status.as_deref()` updated via a perl pass.
- New regression test `test_proxy_list_global_config_fixture_decodes_with_u64_maxmemory_clients` mounts `proxies_list.json` verbatim via `include_str!` and asserts the global-proxy shape decodes plus that `maxmemory_clients` round-trips as `4_294_967_296`.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace` — all pass

Closes #64
Refs #62 (proxies's `GET` response is a bare array, not a wrapper — no list-wrapper change needed here)