### PR TITLE
fix(types): unwrap {crdbs} / {bdb_groups} wrappers on list endpoints

### DIFF
--- a/src/bdb_groups.rs
+++ b/src/bdb_groups.rs
@@ -25,6 +25,17 @@ pub struct BdbGroup {
     pub members: Option<Vec<String>>,
 }
 
+/// Response wrapper for `GET /v1/bdb_groups`.
+///
+/// The API returns `{"bdb_groups": [...]}`. Kept private; consumers go
+/// through [`BdbGroupsHandler::list`] which unwraps to a flat
+/// `Vec<BdbGroup>`.
+#[derive(Debug, Clone, Deserialize)]
+struct BdbGroupsListResponse {
+    #[serde(default)]
+    bdb_groups: Vec<BdbGroup>,
+}
+
 /// Handler for database group operations
 pub struct BdbGroupsHandler {
     client: RestClient,
@@ -35,8 +46,14 @@ impl BdbGroupsHandler {
         BdbGroupsHandler { client }
     }
 
+    /// List all database groups.
+    ///
+    /// `GET /v1/bdb_groups`. The API wraps the array under a
+    /// `bdb_groups` key; this method unwraps the wrapper so callers
+    /// get a flat `Vec<BdbGroup>`.
     pub async fn list(&self) -> Result<Vec<BdbGroup>> {
-        self.client.get("/v1/bdb_groups").await
+        let resp: BdbGroupsListResponse = self.client.get("/v1/bdb_groups").await?;
+        Ok(resp.bdb_groups)
     }
 
     pub async fn get(&self, uid: u32) -> Result<BdbGroup> {

--- a/src/crdb.rs
+++ b/src/crdb.rs
@@ -120,6 +120,17 @@ pub struct CreateCrdbInstance {
     pub password: Option<String>,
 }
 
+/// Response wrapper for `GET /v1/crdbs`.
+///
+/// The API returns `{"crdbs": [...]}`. Kept private to the module since
+/// [`CrdbHandler::list`] unwraps it; only exposed in the public API via
+/// the flat `Vec<Crdb>` return.
+#[derive(Debug, Clone, Deserialize)]
+struct CrdbsListResponse {
+    #[serde(default)]
+    crdbs: Vec<Crdb>,
+}
+
 /// CRDB handler for managing Active-Active databases
 pub struct CrdbHandler {
     client: RestClient,
@@ -130,9 +141,14 @@ impl CrdbHandler {
         CrdbHandler { client }
     }
 
-    /// List all CRDBs
+    /// List all CRDBs.
+    ///
+    /// `GET /v1/crdbs`. The API wraps the array under a `crdbs` key
+    /// (`{"crdbs": [...]}`); this method unwraps it so callers get a
+    /// flat `Vec<Crdb>`.
     pub async fn list(&self) -> Result<Vec<Crdb>> {
-        self.client.get("/v1/crdbs").await
+        let resp: CrdbsListResponse = self.client.get("/v1/crdbs").await?;
+        Ok(resp.crdbs)
     }
 
     /// Get specific CRDB

--- a/tests/bdb_groups_tests.rs
+++ b/tests/bdb_groups_tests.rs
@@ -23,18 +23,21 @@ mod tests {
         let mock_server = MockServer::start().await;
         let handler = setup_mock_client(&mock_server).await;
 
-        let response_body = json!([
-            {
-                "uid": 1,
-                "name": "group1",
-                "bdbs": [1, 2, 3]
-            },
-            {
-                "uid": 2,
-                "name": "group2",
-                "bdbs": [4, 5]
-            }
-        ]);
+        // Regression guard for #62: real API wraps the list under `bdb_groups`.
+        let response_body = json!({
+            "bdb_groups": [
+                {
+                    "uid": 1,
+                    "name": "group1",
+                    "bdbs": [1, 2, 3]
+                },
+                {
+                    "uid": 2,
+                    "name": "group2",
+                    "bdbs": [4, 5]
+                }
+            ]
+        });
 
         Mock::given(method("GET"))
             .and(path("/v1/bdb_groups"))

--- a/tests/crdb_tests.rs
+++ b/tests/crdb_tests.rs
@@ -92,13 +92,13 @@ fn test_crdb_tasks_data() -> serde_json::Value {
 async fn test_crdbs_list() {
     let mock_server = MockServer::start().await;
 
+    // Regression guard for #62: real API wraps the list under `crdbs`.
     Mock::given(method("GET"))
         .and(path("/v1/crdbs"))
         .and(basic_auth("admin", "password"))
-        .respond_with(success_response(json!([
-            test_crdb_full(),
-            test_crdb_simple()
-        ])))
+        .respond_with(success_response(json!({
+            "crdbs": [test_crdb_full(), test_crdb_simple()]
+        })))
         .mount(&mock_server)
         .await;
 
@@ -129,7 +129,7 @@ async fn test_crdbs_list_empty() {
     Mock::given(method("GET"))
         .and(path("/v1/crdbs"))
         .and(basic_auth("admin", "password"))
-        .respond_with(success_response(json!([])))
+        .respond_with(success_response(json!({ "crdbs": [] })))
         .mount(&mock_server)
         .await;
 


### PR DESCRIPTION
## Summary

Two more wrapper-decode bugs from #62. Verified against the recorded fixtures `tests/fixtures/crdbs_list.json` and `bdb_groups_list.json`.

| Method | Wire shape | Action |
|---|---|---|
| `CrdbHandler::list` | `{"crdbs": [...]}` | new private `CrdbsListResponse` wrapper; `list()` unwraps |
| `BdbGroupsHandler::list` | `{"bdb_groups": [...]}` | new private `BdbGroupsListResponse` wrapper; `list()` unwraps |

Both wrappers are `Deserialize`-only with `#[serde(default)]` inner fields, so empty responses just give an empty `Vec`.

## Tests

Existing list tests updated to mount the wrapper shape (matches the recorded fixtures). They previously asserted the buggy bare-array behavior.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace` — all pass

Refs #62 (crdb + bdb_groups slices closed; bootstrap status reshape and cluster_alerts map shape ship in follow-up PRs)