### PR TITLE
fix(bootstrap): reshape status response to match the documented spec wrapper

### DIFF
--- a/src/bootstrap.rs
+++ b/src/bootstrap.rs
@@ -98,17 +98,46 @@ pub struct CredentialsBootstrap {
     pub password: String,
 }
 
-/// Bootstrap status response
+/// Inner bootstrap state, as carried inside [`BootstrapStatusResponse`].
+///
+/// The Redis Enterprise REST API uses the field name `state`
+/// (not `status`) for the bootstrap lifecycle value, and pairs it with
+/// `start_time` and `end_time`. The previous shape (`status` /
+/// `progress` / `message`) did not match the wire response —
+/// see `tests/fixtures/bootstrap_status.json`.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct BootstrapStatus {
-    /// Current status of the bootstrap operation
-    pub status: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    /// Progress percentage (0.0-100.0) of the bootstrap operation
-    pub progress: Option<f32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    /// Status message or error description
-    pub message: Option<String>,
+    /// Current bootstrap state (e.g. `"idle"`, `"initializing"`,
+    /// `"completed"`, `"failed"`).
+    pub state: String,
+    /// ISO-8601 timestamp when the bootstrap began.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub start_time: Option<String>,
+    /// ISO-8601 timestamp when the bootstrap reached its terminal state.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub end_time: Option<String>,
+}
+
+/// Response wrapper for `GET /v1/bootstrap` (and `POST /v1/bootstrap` /
+/// `POST /v1/bootstrap/join`).
+///
+/// The Redis Enterprise API wraps the bootstrap state in a top-level
+/// `bootstrap_status` field and includes a `local_node_info` object
+/// describing the node that received the request. The previous Rust
+/// shape collapsed these into a single struct and used the wrong
+/// field names; the resulting decode failed against real responses.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BootstrapStatusResponse {
+    /// Inner bootstrap state.
+    pub bootstrap_status: BootstrapStatus,
+    /// Information about the local node that handled the request.
+    ///
+    /// Typed as `serde_json::Value` because the contents are
+    /// version-specific and operator-oriented (CPU/storage info,
+    /// supported Redis versions, software version, etc.); see the
+    /// recorded `bootstrap_status.json` fixture.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub local_node_info: Option<Value>,
 }
 
 /// Bootstrap handler for cluster initialization
@@ -121,18 +150,27 @@ impl BootstrapHandler {
         BootstrapHandler { client }
     }
 
-    /// Initialize cluster bootstrap
-    pub async fn create(&self, config: BootstrapConfig) -> Result<BootstrapStatus> {
+    /// Initialize cluster bootstrap.
+    ///
+    /// `POST /v1/bootstrap`. Returns the [`BootstrapStatusResponse`]
+    /// wrapper (`bootstrap_status` + optional `local_node_info`).
+    pub async fn create(&self, config: BootstrapConfig) -> Result<BootstrapStatusResponse> {
         self.client.post("/v1/bootstrap", &config).await
     }
 
-    /// Get bootstrap status
-    pub async fn status(&self) -> Result<BootstrapStatus> {
+    /// Get current bootstrap status.
+    ///
+    /// `GET /v1/bootstrap`. Returns the [`BootstrapStatusResponse`]
+    /// wrapper.
+    pub async fn status(&self) -> Result<BootstrapStatusResponse> {
         self.client.get("/v1/bootstrap").await
     }
 
-    /// Join node to existing cluster
-    pub async fn join(&self, config: BootstrapConfig) -> Result<BootstrapStatus> {
+    /// Join this node to an existing cluster.
+    ///
+    /// `POST /v1/bootstrap/join`. Returns the [`BootstrapStatusResponse`]
+    /// wrapper.
+    pub async fn join(&self, config: BootstrapConfig) -> Result<BootstrapStatusResponse> {
         self.client.post("/v1/bootstrap/join", &config).await
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -432,8 +432,8 @@ pub use local::LocalHandler;
 
 // Bootstrap
 pub use bootstrap::{
-    BootstrapConfig, BootstrapHandler, BootstrapStatus, ClusterBootstrap, CredentialsBootstrap,
-    NodeBootstrap, NodePaths,
+    BootstrapConfig, BootstrapHandler, BootstrapStatus, BootstrapStatusResponse, ClusterBootstrap,
+    CredentialsBootstrap, NodeBootstrap, NodePaths,
 };
 
 // Cluster Manager settings

--- a/tests/bootstrap_tests.rs
+++ b/tests/bootstrap_tests.rs
@@ -21,15 +21,25 @@ fn no_content_response() -> ResponseTemplate {
     ResponseTemplate::new(204)
 }
 
+// Produces the real wire shape: { "bootstrap_status": { "state", "start_time", "end_time" }, "local_node_info": {...} }.
+// The old `(status, progress, message)` shape collapsed all three into the inner object; only
+// `state` is documented in the REST API (the other two are kept here for backward-compatible
+// test signatures but discarded — they were never on the wire).
 fn bootstrap_status_response(
-    status: &str,
-    progress: Option<f32>,
-    message: Option<&str>,
+    state: &str,
+    _progress: Option<f32>,
+    _message: Option<&str>,
 ) -> serde_json::Value {
     json!({
-        "status": status,
-        "progress": progress,
-        "message": message
+        "bootstrap_status": {
+            "state": state,
+            "start_time": "2026-05-20T15:00:00Z",
+            "end_time": null
+        },
+        "local_node_info": {
+            "architecture": "x86_64",
+            "os_family": "ubuntu"
+        }
     })
 }
 
@@ -99,9 +109,7 @@ async fn test_bootstrap_create_cluster() {
 
     assert!(result.is_ok());
     let status = result.unwrap();
-    assert_eq!(status.status, "in_progress");
-    assert_eq!(status.progress, Some(10.0));
-    assert_eq!(status.message, Some("Initializing cluster".to_string()));
+    assert_eq!(status.bootstrap_status.state, "in_progress");
 }
 
 #[tokio::test]
@@ -131,12 +139,7 @@ async fn test_bootstrap_status_in_progress() {
 
     assert!(result.is_ok());
     let status = result.unwrap();
-    assert_eq!(status.status, "in_progress");
-    assert_eq!(status.progress, Some(75.5));
-    assert_eq!(
-        status.message,
-        Some("Configuring cluster nodes".to_string())
-    );
+    assert_eq!(status.bootstrap_status.state, "in_progress");
 }
 
 #[tokio::test]
@@ -166,8 +169,7 @@ async fn test_bootstrap_status_completed() {
 
     assert!(result.is_ok());
     let status = result.unwrap();
-    assert_eq!(status.status, "completed");
-    assert_eq!(status.progress, Some(100.0));
+    assert_eq!(status.bootstrap_status.state, "completed");
 }
 
 #[tokio::test]
@@ -197,12 +199,7 @@ async fn test_bootstrap_status_failed() {
 
     assert!(result.is_ok());
     let status = result.unwrap();
-    assert_eq!(status.status, "failed");
-    assert_eq!(status.progress, Some(45.0));
-    assert_eq!(
-        status.message,
-        Some("Failed to connect to cluster node".to_string())
-    );
+    assert_eq!(status.bootstrap_status.state, "failed");
 }
 
 #[tokio::test]
@@ -259,9 +256,7 @@ async fn test_bootstrap_join_node() {
 
     assert!(result.is_ok());
     let status = result.unwrap();
-    assert_eq!(status.status, "in_progress");
-    assert_eq!(status.progress, Some(5.0));
-    assert_eq!(status.message, Some("Joining node to cluster".to_string()));
+    assert_eq!(status.bootstrap_status.state, "in_progress");
 }
 
 #[tokio::test]
@@ -327,6 +322,50 @@ async fn test_bootstrap_create_minimal_config() {
 
     assert!(result.is_ok());
     let status = result.unwrap();
-    assert_eq!(status.status, "in_progress");
-    assert_eq!(status.progress, Some(0.0));
+    assert_eq!(status.bootstrap_status.state, "in_progress");
+}
+
+#[tokio::test]
+async fn test_bootstrap_status_decodes_recorded_fixture() {
+    // Regression guard for #62: the recorded fixture has the canonical
+    // wrapper shape — bootstrap_status with state/start_time/end_time
+    // plus a sizeable local_node_info object. The previous
+    // (status/progress/message) struct decode-failed against this.
+    let mock_server = MockServer::start().await;
+
+    let fixture: serde_json::Value =
+        serde_json::from_str(include_str!("fixtures/bootstrap_status.json"))
+            .expect("fixture should be valid JSON");
+
+    Mock::given(method("GET"))
+        .and(path("/v1/bootstrap"))
+        .and(basic_auth("admin", "password"))
+        .respond_with(success_response(fixture))
+        .mount(&mock_server)
+        .await;
+
+    let client = EnterpriseClient::builder()
+        .base_url(mock_server.uri())
+        .username("admin")
+        .password("password")
+        .build()
+        .unwrap();
+
+    let handler = BootstrapHandler::new(client);
+    let response = handler.status().await.expect("fixture should decode");
+
+    assert_eq!(response.bootstrap_status.state, "completed");
+    assert_eq!(
+        response.bootstrap_status.start_time.as_deref(),
+        Some("2025-10-14T00:01:06Z")
+    );
+    assert_eq!(
+        response.bootstrap_status.end_time.as_deref(),
+        Some("2025-10-14T00:01:22Z")
+    );
+
+    let node = response
+        .local_node_info
+        .expect("fixture has local_node_info");
+    assert_eq!(node["os_family"], "ubuntu");
 }


### PR DESCRIPTION
## Summary

`GET /v1/bootstrap` returns:

```json
{ "bootstrap_status": { "state", "start_time", "end_time" },
  "local_node_info": { ... } }
```

The previous Rust struct (`status` / `progress` / `message`) did not match the wire response — every real call to `status()` decode-failed against the recorded `tests/fixtures/bootstrap_status.json`.

## Type changes

- `BootstrapStatus` reshaped to the inner state: `state` (renamed from `status`), `start_time`, `end_time`. `progress` and `message` dropped (never on the wire).
- New `BootstrapStatusResponse { bootstrap_status, local_node_info: Option<Value> }` wrapper carries the spec layout.
- `BootstrapHandler::{status, create, join}` now return `BootstrapStatusResponse` instead of `BootstrapStatus`.

`local_node_info` is `Option<Value>` because its contents are version-specific operator info (CPU/storage, supported Redis versions, etc.); strict typing would create a brittle decode surface for what is effectively diagnostic JSON.

## Breaking changes

| Old | New |
|---|---|
| `BootstrapStatus.status` | `BootstrapStatus.state` |
| `BootstrapStatus.progress` | _(removed; never on the wire)_ |
| `BootstrapStatus.message` | _(removed)_ |
| `create/status/join` return type | `BootstrapStatusResponse` |

The previous typing decode-failed on every real response, so no production caller can have been relying on the old shape.

## Tests

- `bootstrap_status_response` helper now produces the wrapper shape; existing tests keep their call signatures.
- Old `.status` / `.progress` / `.message` assertions rewritten or removed.
- New `test_bootstrap_status_decodes_recorded_fixture` mounts `bootstrap_status.json` verbatim and asserts the wrapper decodes including `local_node_info`.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace` — all pass

Refs #62 (bootstrap slice closed; `cluster_alerts` map shape ships in a follow-up PR)