### PR TITLE
fix(alerts): list_cluster_alerts returns HashMap<String, ClusterAlertState>

### DIFF
--- a/src/alerts.rs
+++ b/src/alerts.rs
@@ -9,6 +9,7 @@ use crate::client::RestClient;
 use crate::error::Result;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
+use std::collections::HashMap;
 
 /// Alert information
 /// Represents an alert state for a cluster object (database, node, or cluster)
@@ -46,6 +47,34 @@ pub struct Alert {
     /// Error code associated with the alert
     #[serde(skip_serializing_if = "Option::is_none")]
     pub error_code: Option<String>,
+}
+
+/// Cluster-alert state as returned by `GET /v1/cluster/alerts`.
+///
+/// The cluster-alerts endpoint returns a map keyed by alert name —
+/// for example `cluster_ca_cert_about_to_expire`,
+/// `cluster_multiple_nodes_down`, etc. — whose values share this
+/// shape. The alert name itself lives in the map key, not in this
+/// struct.
+///
+/// Distinct from [`Alert`], which models the documented alert object
+/// used by the `/v1/bdbs/{uid}/alerts` and `/v1/nodes/{uid}/alerts`
+/// endpoints and the catalog at `/v1/alerts`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ClusterAlertState {
+    /// Whether this alert is configured to fire.
+    pub enabled: bool,
+    /// Whether the alert is currently triggered.
+    pub state: bool,
+    /// Severity level (e.g. `"INFO"`, `"WARNING"`).
+    pub severity: String,
+    /// ISO-8601 timestamp of the last state change.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub change_time: Option<String>,
+    /// Alert-specific snapshot taken at the last state change
+    /// (thresholds, sampled values, etc.). Shape varies per alert.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub change_value: Option<Value>,
 }
 
 /// Generic alert settings (legacy - kept for compatibility)
@@ -245,8 +274,16 @@ impl AlertHandler {
             .await
     }
 
-    /// List alerts for the cluster
-    pub async fn list_cluster_alerts(&self) -> Result<Vec<Alert>> {
+    /// List active cluster-level alerts.
+    ///
+    /// `GET /v1/cluster/alerts`. The API returns a map keyed by alert
+    /// name (e.g. `cluster_multiple_nodes_down`), so the return type is
+    /// `HashMap<String, ClusterAlertState>`. The alert name itself is
+    /// the map key. See [`ClusterAlertState`] for the per-entry shape.
+    ///
+    /// Distinct from [`Self::list`], which returns the documented
+    /// `Alert` objects from `/v1/alerts`.
+    pub async fn list_cluster_alerts(&self) -> Result<HashMap<String, ClusterAlertState>> {
         self.client.get("/v1/cluster/alerts").await
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -408,7 +408,7 @@ pub use crdb::{Crdb, CrdbHandler, CrdbInstance, CreateCrdbInstance, CreateCrdbRe
 pub use stats::{StatsHandler, StatsInterval, StatsQuery, StatsResponse};
 
 // Alerts
-pub use alerts::{Alert, AlertHandler, AlertSettings};
+pub use alerts::{Alert, AlertHandler, AlertSettings, ClusterAlertState};
 
 // Redis ACLs
 pub use redis_acls::{CreateRedisAclRequest, RedisAcl, RedisAclHandler};

--- a/tests/alerts_tests.rs
+++ b/tests/alerts_tests.rs
@@ -50,17 +50,6 @@ fn test_database_alert() -> serde_json::Value {
     })
 }
 
-fn test_cluster_alert() -> serde_json::Value {
-    json!({
-        "uid": "alert-789",
-        "name": "cluster_memory_usage",
-        "severity": "low",
-        "state": "resolved",
-        "entity_type": "cluster",
-        "description": "Cluster memory usage warning"
-    })
-}
-
 #[tokio::test]
 async fn test_alerts_list() {
     let mock_server = MockServer::start().await;
@@ -273,12 +262,27 @@ async fn test_alerts_list_by_node_nonexistent() {
 
 #[tokio::test]
 async fn test_alerts_list_cluster_alerts() {
+    // Regression guard for #62: cluster alerts are returned as a map
+    // keyed by alert name, not as a bare array of Alert objects.
     let mock_server = MockServer::start().await;
 
     Mock::given(method("GET"))
         .and(path("/v1/cluster/alerts"))
         .and(basic_auth("admin", "password"))
-        .respond_with(success_response(json!([test_cluster_alert()])))
+        .respond_with(success_response(json!({
+            "cluster_multiple_nodes_down": {
+                "enabled": true,
+                "state": false,
+                "severity": "WARNING",
+                "change_time": "2026-05-20T00:00:00Z",
+                "change_value": { "dead_nodes": [], "state": false }
+            },
+            "cluster_ram_overcommit": {
+                "enabled": false,
+                "state": false,
+                "severity": "INFO"
+            }
+        })))
         .mount(&mock_server)
         .await;
 
@@ -290,13 +294,17 @@ async fn test_alerts_list_cluster_alerts() {
         .unwrap();
 
     let handler = AlertHandler::new(client);
-    let result = handler.list_cluster_alerts().await;
+    let alerts = handler.list_cluster_alerts().await.unwrap();
 
-    assert!(result.is_ok());
-    let alerts = result.unwrap();
-    assert_eq!(alerts.len(), 1);
-    assert_eq!(alerts[0].uid, "alert-789");
-    assert_eq!(alerts[0].entity_type.as_ref().unwrap(), "cluster");
+    assert_eq!(alerts.len(), 2);
+    let multi = alerts.get("cluster_multiple_nodes_down").unwrap();
+    assert!(multi.enabled);
+    assert!(!multi.state);
+    assert_eq!(multi.severity, "WARNING");
+
+    let overcommit = alerts.get("cluster_ram_overcommit").unwrap();
+    assert!(!overcommit.enabled);
+    assert!(overcommit.change_time.is_none());
 }
 
 #[tokio::test]
@@ -515,4 +523,49 @@ async fn test_alerts_get_settings_nonexistent() {
     let result = handler.get_settings("nonexistent_alert").await;
 
     assert!(result.is_err());
+}
+
+#[tokio::test]
+async fn test_cluster_alerts_decodes_recorded_fixture() {
+    // Regression guard for #62: the recorded fixture has the real
+    // wire shape — a top-level map keyed by alert name where each
+    // entry exposes enabled/state/severity/change_time/change_value.
+    let mock_server = MockServer::start().await;
+
+    let fixture: serde_json::Value =
+        serde_json::from_str(include_str!("fixtures/cluster_alerts.json"))
+            .expect("fixture should be valid JSON");
+
+    Mock::given(method("GET"))
+        .and(path("/v1/cluster/alerts"))
+        .and(basic_auth("admin", "password"))
+        .respond_with(success_response(fixture))
+        .mount(&mock_server)
+        .await;
+
+    let client = EnterpriseClient::builder()
+        .base_url(mock_server.uri())
+        .username("admin")
+        .password("password")
+        .build()
+        .unwrap();
+
+    let handler = AlertHandler::new(client);
+    let alerts = handler
+        .list_cluster_alerts()
+        .await
+        .expect("fixture should decode");
+
+    // The recorded fixture has 12 cluster alerts.
+    assert_eq!(alerts.len(), 12);
+
+    let nodes_down = alerts
+        .get("cluster_even_node_count")
+        .expect("fixture has cluster_even_node_count");
+    assert_eq!(nodes_down.severity, "WARNING");
+    assert!(
+        nodes_down.state,
+        "cluster_even_node_count is firing in the fixture"
+    );
+    assert!(!nodes_down.enabled);
 }


### PR DESCRIPTION
## Summary

`GET /v1/cluster/alerts` returns a top-level map keyed by alert name where each value carries `{ enabled, state, severity, change_time, change_value }`. The previous `Vec<Alert>` return type decoded against an `Alert` shape (`uid`/`name`/`entity_type`/...) that this endpoint does not produce. Verified against the recorded `tests/fixtures/cluster_alerts.json` (12 alerts, all of which decode-failed on the old type).

## Type changes

- New `ClusterAlertState` struct:
  ```rust
  pub struct ClusterAlertState {
      pub enabled: bool,
      pub state: bool,
      pub severity: String,
      pub change_time: Option<String>,
      pub change_value: Option<Value>,
  }
  ```
- `AlertHandler::list_cluster_alerts` now returns `HashMap<String, ClusterAlertState>`; the alert name lives in the map key (where the API puts it).
- `Alert` is unchanged — it continues to model the documented alert object for `/v1/alerts`, `/v1/bdbs/{uid}/alerts`, `/v1/nodes/{uid}/alerts`.

## Breaking change

`list_cluster_alerts()` return type widens from `Vec<Alert>` to `HashMap<String, ClusterAlertState>`. The old shape decode-failed on every real response, so no production caller can have been relying on it.

## Tests

- `test_alerts_list_cluster_alerts` rewritten to mount the map shape and assert via `alerts.get(...)`. Previously mounted a bare Alert array.
- New `test_cluster_alerts_decodes_recorded_fixture` mounts `cluster_alerts.json` verbatim and verifies all 12 alerts decode plus one firing alert (`cluster_even_node_count`) has the expected state/severity/enabled triple.
- The old `test_cluster_alert` helper was the only caller producing the documented Alert shape for this endpoint; removed as dead code.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace` — all pass

Closes #62 (last of the wrapper-decode slices — actions, crdb, bdb_groups, bootstrap, proxies, cluster_alerts now all shipped or in flight)