### PR TITLE
docs(missing-docs): document fields and enum variants across the crate

### DIFF
--- a/src/actions.rs
+++ b/src/actions.rs
@@ -94,6 +94,7 @@ pub struct ActionHandler {
 }
 
 impl ActionHandler {
+    /// Create a new action handler bound to the given REST client.
     pub fn new(client: RestClient) -> Self {
         ActionHandler { client }
     }
@@ -161,15 +162,18 @@ impl ActionHandler {
     }
 
     // Versioned sub-handlers for clearer API
+    /// Returns a v1-scoped sub-handler for `/v1/actions` endpoints.
     pub fn v1(&self) -> v1::ActionsV1 {
         v1::ActionsV1::new(self.client.clone())
     }
 
+    /// Returns a v2-scoped sub-handler for `/v2/actions` endpoints.
     pub fn v2(&self) -> v2::ActionsV2 {
         v2::ActionsV2::new(self.client.clone())
     }
 }
 
+/// V1 action endpoints (`/v1/actions`).
 pub mod v1 {
     use super::{Action, ActionsListResponse, RestClient};
     use crate::error::Result;
@@ -219,10 +223,12 @@ pub mod v1 {
     }
 }
 
+/// V2 action endpoints (`/v2/actions`).
 pub mod v2 {
     use super::{Action, RestClient};
     use crate::error::Result;
 
+    /// V2 sub-handler for `/v2/actions` endpoints.
     pub struct ActionsV2 {
         client: RestClient,
     }
@@ -232,10 +238,12 @@ pub mod v2 {
             Self { client }
         }
 
+        /// List all v2 actions.
         pub async fn list(&self) -> Result<Vec<Action>> {
             self.client.get("/v2/actions").await
         }
 
+        /// Get a single v2 action by UID.
         pub async fn get(&self, action_uid: &str) -> Result<Action> {
             self.client
                 .get(&format!("/v2/actions/{}", action_uid))

--- a/src/alerts.rs
+++ b/src/alerts.rs
@@ -246,6 +246,7 @@ pub struct AlertHandler {
 pub type AlertsHandler = AlertHandler;
 
 impl AlertHandler {
+    /// Create a new handler bound to the given REST client.
     pub fn new(client: RestClient) -> Self {
         AlertHandler { client }
     }

--- a/src/bdb.rs
+++ b/src/bdb.rs
@@ -78,8 +78,11 @@ use tokio::time::sleep;
 use typed_builder::TypedBuilder;
 
 // Aliases for easier use
+/// Alias for [`DatabaseInfo`]; the BDB ("Berkeley DB") naming is legacy Redis Enterprise terminology.
 pub type Database = DatabaseInfo;
+/// Alias for [`DatabaseHandler`]; retained for backwards compatibility.
 pub type BdbHandler = DatabaseHandler;
+/// Stream of database state updates yielded by the database watcher.
 pub type DatabaseWatchStream<'a> =
     Pin<Box<dyn Stream<Item = Result<(DatabaseInfo, Option<String>)>> + Send + 'a>>;
 
@@ -201,61 +204,100 @@ pub struct DatabaseUpgradeRequest {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct DatabaseInfo {
     // Core database identification and status
+    /// Database's unique ID (read-only).
     pub uid: u32,
+    /// Database name.
     pub name: String,
+    /// TCP port on which the database is available (read-only).
     pub port: Option<u16>,
+    /// Current status of the database (e.g. `"active"`, `"pending"`).
     pub status: Option<String>,
+    /// Database memory limit in bytes (0 for unlimited).
     pub memory_size: Option<u64>,
+    /// Current memory usage in bytes (read-only).
     pub memory_used: Option<u64>,
 
     /// Database type (e.g., "redis", "memcached")
     #[serde(rename = "type")]
     pub type_: Option<String>,
+    /// Database version (read-only).
     pub version: Option<String>,
 
     /// Account and action tracking
     pub account_id: Option<u32>,
+    /// UID of the most recent action affecting this database (read-only).
     pub action_uid: Option<String>,
 
     // Sharding and placement
+    /// Number of database shards.
     pub shards_count: Option<u32>,
+    /// List of shard UIDs that compose the database.
     pub shard_list: Option<Vec<u32>>,
+    /// Whether the database is sharded.
     pub sharding: Option<bool>,
+    /// Shard placement strategy (e.g. `"dense"`, `"sparse"`).
     pub shards_placement: Option<String>,
+    /// Whether in-memory replication is enabled.
     pub replication: Option<bool>,
 
     // Endpoints and networking
+    /// Endpoints exposed by this database. See [`EndpointInfo`].
     pub endpoints: Option<Vec<EndpointInfo>>,
+    /// Primary endpoint address (read-only).
     pub endpoint: Option<String>,
+    /// List of endpoint IP addresses (read-only).
     pub endpoint_ip: Option<Vec<String>>,
+    /// Node UID that currently hosts the endpoint (read-only).
     pub endpoint_node: Option<u32>,
+    /// DNS name pointing to the master endpoint (read-only).
     pub dns_address_master: Option<String>,
 
     // Data persistence and backup
+    /// Persistence policy (e.g. `"disabled"`, `"aof"`, `"snapshot"`).
     pub persistence: Option<String>,
+    /// Data persistence mode (alias for `persistence` on some API versions).
     pub data_persistence: Option<String>,
+    /// Eviction policy when the database reaches its memory limit (e.g. `"allkeys-lru"`).
     pub eviction_policy: Option<String>,
 
     // Timestamps
+    /// Timestamp when the database was created (ISO-8601).
     pub created_time: Option<String>,
+    /// Timestamp of the most recent configuration change (ISO-8601).
     pub last_changed_time: Option<String>,
+    /// Timestamp of the most recent successful backup (ISO-8601).
     pub last_backup_time: Option<String>,
+    /// Timestamp of the most recent successful export (ISO-8601).
     pub last_export_time: Option<String>,
 
     // Security and authentication
+    /// Whether weak hashing is permitted for mTLS connections.
     pub mtls_allow_weak_hashing: Option<bool>,
+    /// Whether outdated/expired certificates are permitted for mTLS connections.
     pub mtls_allow_outdated_certs: Option<bool>,
+    /// Redis password used for client authentication.
     pub authentication_redis_pass: Option<String>,
+    /// Admin password used for elevated authentication.
     pub authentication_admin_pass: Option<String>,
+    /// SASL password (Memcached databases).
     pub authentication_sasl_pass: Option<String>,
+    /// SASL username (Memcached databases).
     pub authentication_sasl_uname: Option<String>,
+    /// List of SSL client certificates accepted for authentication.
     pub authentication_ssl_client_certs: Option<Vec<Value>>,
+    /// List of SSL certificates trusted for CRDT (Active-Active) connections.
     pub authentication_ssl_crdt_certs: Option<Vec<Value>>,
+    /// List of authorized subjects for certificate-based authentication.
     pub authorized_subjects: Option<Vec<Value>>,
+    /// Whether inter-node data encryption is enabled.
     pub data_internode_encryption: Option<bool>,
+    /// Whether SSL/TLS is required for client connections.
     pub ssl: Option<bool>,
+    /// TLS mode for client connections (e.g. `"enabled"`, `"disabled"`).
     pub tls_mode: Option<String>,
+    /// Client certificate enforcement mode (e.g. `"enabled"`, `"disabled"`).
     pub enforce_client_authentication: Option<String>,
+    /// Whether the default Redis user is enabled.
     pub default_user: Option<bool>,
     /// ACL configuration
     pub acl: Option<Value>,
@@ -271,84 +313,147 @@ pub struct DatabaseInfo {
     pub redis_cluster_enabled: Option<bool>,
 
     // CRDT/Active-Active fields
+    /// Whether this database participates in a CRDT (Active-Active) deployment.
     pub crdt: Option<bool>,
+    /// Whether CRDT (Active-Active) functionality is enabled.
     pub crdt_enabled: Option<bool>,
+    /// CRDT configuration version.
     pub crdt_config_version: Option<u32>,
+    /// Replica ID assigned to this database in the CRDT cluster.
     pub crdt_replica_id: Option<u32>,
+    /// Comma-separated list of replica IDs that have been removed from the CRDT.
     pub crdt_ghost_replica_ids: Option<String>,
+    /// CRDT feature-set version.
     pub crdt_featureset_version: Option<u32>,
+    /// CRDT protocol version.
     pub crdt_protocol_version: Option<u32>,
+    /// Globally unique identifier for the CRDT.
     pub crdt_guid: Option<String>,
+    /// Modules configuration for the CRDT.
     pub crdt_modules: Option<String>,
+    /// Comma-separated list of CRDT replica endpoints.
     pub crdt_replicas: Option<String>,
+    /// List of CRDT replica sources.
     pub crdt_sources: Option<Vec<Value>>,
+    /// CRDT sync state (e.g. `"enabled"`, `"disabled"`).
     pub crdt_sync: Option<String>,
+    /// Seconds before a stalled CRDT sync connection raises an alarm.
     pub crdt_sync_connection_alarm_timeout_seconds: Option<u32>,
+    /// Whether CRDT sync is distributed across shards.
     pub crdt_sync_dist: Option<bool>,
+    /// Whether the CRDT syncer auto-unlatches on out-of-memory conditions.
     pub crdt_syncer_auto_oom_unlatch: Option<bool>,
+    /// XADD stream ID uniqueness mode for CRDT.
     pub crdt_xadd_id_uniqueness_mode: Option<String>,
+    /// Whether CRDT causal consistency is enabled.
     pub crdt_causal_consistency: Option<bool>,
+    /// Replication backlog size for CRDT (bytes, or `"auto"`).
     pub crdt_repl_backlog_size: Option<String>,
 
     // Replication settings
+    /// Whether persistence is enabled on the master shard.
     pub master_persistence: Option<bool>,
+    /// Whether slave (replica) high availability is enabled.
     pub slave_ha: Option<bool>,
+    /// Priority for slave HA replica selection.
     pub slave_ha_priority: Option<u32>,
+    /// Whether replica shards are read-only.
     pub replica_read_only: Option<bool>,
+    /// List of upstream replica sources for Replica-Of mode.
     pub replica_sources: Option<Vec<Value>>,
+    /// Replica sync state (e.g. `"enabled"`, `"paused"`).
     pub replica_sync: Option<String>,
+    /// Seconds before a stalled replica sync connection raises an alarm.
     pub replica_sync_connection_alarm_timeout_seconds: Option<u32>,
+    /// Whether replica sync is distributed across shards.
     pub replica_sync_dist: Option<bool>,
+    /// Replication backlog size (bytes, or `"auto"`).
     pub repl_backlog_size: Option<String>,
 
     // Connection and performance settings
+    /// Maximum number of client connections (alias for `maxclients` on some versions).
     pub max_connections: Option<u32>,
+    /// Maximum number of concurrent client connections.
     pub maxclients: Option<u32>,
+    /// Number of proxy connection threads.
     pub conns: Option<u32>,
+    /// Proxy connection type (e.g. `"per-thread"`, `"per-shard"`).
     pub conns_type: Option<String>,
+    /// Maximum number of pipelined commands per client.
     pub max_client_pipeline: Option<u32>,
+    /// Maximum number of pipelined commands.
     pub max_pipelined: Option<u32>,
 
     // AOF (Append Only File) settings
+    /// AOF (append-only file) fsync policy (e.g. `"appendfsync-every-sec"`).
     pub aof_policy: Option<String>,
+    /// Maximum AOF file size in bytes.
     pub max_aof_file_size: Option<u64>,
+    /// Maximum AOF load time in seconds.
     pub max_aof_load_time: Option<u32>,
 
     // Active defragmentation settings
+    /// Active defragmentation toggle (e.g. `"enabled"`, `"disabled"`).
     pub activedefrag: Option<String>,
+    /// Maximum CPU percentage used by active defrag.
     pub active_defrag_cycle_max: Option<u32>,
+    /// Minimum CPU percentage used by active defrag.
     pub active_defrag_cycle_min: Option<u32>,
+    /// Minimum amount of fragmentation waste (bytes) before defrag starts.
     pub active_defrag_ignore_bytes: Option<String>,
+    /// Maximum number of fields scanned per defrag cycle.
     pub active_defrag_max_scan_fields: Option<u32>,
+    /// Lower fragmentation threshold (percent) for active defrag.
     pub active_defrag_threshold_lower: Option<u32>,
+    /// Upper fragmentation threshold (percent) for active defrag.
     pub active_defrag_threshold_upper: Option<u32>,
 
     // Backup settings
+    /// Whether periodic backup is enabled.
     pub backup: Option<bool>,
+    /// Reason for the most recent backup failure (read-only).
     pub backup_failure_reason: Option<String>,
+    /// Number of backup snapshots retained.
     pub backup_history: Option<u32>,
+    /// Backup interval in seconds.
     pub backup_interval: Option<u32>,
+    /// Offset (in seconds) from midnight when scheduled backups run.
     pub backup_interval_offset: Option<u32>,
+    /// Backup destination location (URI or storage config object).
     pub backup_location: Option<Value>,
+    /// Percent progress (0–100) of the in-flight backup (read-only).
     pub backup_progress: Option<f64>,
+    /// Current backup status (e.g. `"idle"`, `"running"`, `"failed"`).
     pub backup_status: Option<String>,
 
     // Import/Export settings
+    /// List of dataset import source descriptors.
     pub dataset_import_sources: Option<Vec<Value>>,
+    /// Reason for the most recent import failure (read-only).
     pub import_failure_reason: Option<String>,
+    /// Percent progress (0–100) of the in-flight import (read-only).
     pub import_progress: Option<f64>,
+    /// Current import status (e.g. `"idle"`, `"running"`, `"failed"`).
     pub import_status: Option<String>,
+    /// Reason for the most recent export failure (read-only).
     pub export_failure_reason: Option<String>,
+    /// Percent progress (0–100) of the in-flight export (read-only).
     pub export_progress: Option<f64>,
+    /// Current export status (e.g. `"idle"`, `"running"`, `"failed"`).
     pub export_status: Option<String>,
+    /// Skip-analyze policy applied during import.
     pub skip_import_analyze: Option<String>,
 
     // Monitoring and metrics
+    /// Whether all metrics are exported.
     pub metrics_export_all: Option<bool>,
+    /// Whether the text monitor log is generated for this database.
     pub generate_text_monitor: Option<bool>,
+    /// Whether email alerts are enabled for this database.
     pub email_alerts: Option<bool>,
 
     // Modules and features
+    /// List of Redis modules loaded into the database.
     pub module_list: Option<Vec<Value>>,
     /// Search configuration - can be bool or object depending on API version
     #[serde(default)]
@@ -358,80 +463,129 @@ pub struct DatabaseInfo {
     pub timeseries: Option<Value>,
 
     // BigStore/Flash storage settings
+    /// Whether Redis on Flash (BigStore) is enabled.
     pub bigstore: Option<bool>,
+    /// RAM portion of the database (bytes) when BigStore is enabled.
     pub bigstore_ram_size: Option<u64>,
+    /// Maximum percentage of memory used by RAM in BigStore.
     pub bigstore_max_ram_ratio: Option<u32>,
+    /// Per-shard RAM weights for BigStore.
     pub bigstore_ram_weights: Option<Vec<Value>>,
+    /// BigStore version in use.
     pub bigstore_version: Option<u32>,
 
     // Network and proxy settings
+    /// Proxy policy (e.g. `"single"`, `"all-master-shards"`, `"all-nodes"`).
     pub proxy_policy: Option<String>,
+    /// Whether OSS-cluster API compatibility is enabled.
     pub oss_cluster: Option<bool>,
+    /// Preferred endpoint type advertised by the OSS-cluster API (e.g. `"hostname"`, `"ip"`).
     pub oss_cluster_api_preferred_endpoint_type: Option<String>,
+    /// Preferred IP type advertised by the OSS-cluster API (e.g. `"internal"`, `"external"`).
     pub oss_cluster_api_preferred_ip_type: Option<String>,
+    /// Whether OSS-style hash-slot sharding is enabled.
     pub oss_sharding: Option<bool>,
 
     // Redis-specific settings
+    /// Redis Enterprise database server version (read-only).
     pub redis_version: Option<String>,
+    /// Whether RESP3 protocol is enabled.
     pub resp3: Option<bool>,
+    /// Comma-separated list of disabled Redis commands.
     pub disabled_commands: Option<String>,
 
     // Clustering and sharding
+    /// Hash-slot policy (e.g. `"legacy"`, `"16k"`).
     pub hash_slots_policy: Option<String>,
+    /// List of regular expressions used to extract shard keys.
     pub shard_key_regex: Option<Vec<Value>>,
+    /// Whether cross-slot multi-key commands are blocked.
     pub shard_block_crossslot_keys: Option<bool>,
+    /// Whether commands referencing foreign keys are blocked.
     pub shard_block_foreign_keys: Option<bool>,
+    /// Whether implicit shard keys are used.
     pub implicit_shard_key: Option<bool>,
 
     // Node placement and rack awareness
+    /// List of node UIDs to avoid when placing shards.
     pub avoid_nodes: Option<Vec<String>>,
+    /// List of node UIDs preferred for placing shards.
     pub use_nodes: Option<Vec<String>>,
+    /// Whether rack-aware shard placement is enabled.
     pub rack_aware: Option<bool>,
 
     // Operational settings
+    /// Whether automatic Redis upgrades are enabled.
     pub auto_upgrade: Option<bool>,
+    /// Whether this is an internal/system database.
     pub internal: Option<bool>,
+    /// Whether database connection auditing is enabled.
     pub db_conns_auditing: Option<bool>,
+    /// Whether the replica flushes its dataset on full sync.
     pub flush_on_fullsync: Option<bool>,
+    /// Whether selective flush is used for replica sync.
     pub use_selective_flush: Option<bool>,
 
     // Sync and replication control
+    /// Database sync mode.
     pub sync: Option<String>,
+    /// List of sync sources for Replica-Of configurations.
     pub sync_sources: Option<Vec<Value>>,
+    /// Number of dedicated threads used by the syncer.
     pub sync_dedicated_threads: Option<u32>,
+    /// Syncer mode (e.g. `"distributed"`, `"centralized"`).
     pub syncer_mode: Option<String>,
+    /// Log level used by the syncer.
     pub syncer_log_level: Option<String>,
+    /// Whether the syncer supports on-the-fly reconfiguration.
     pub support_syncer_reconf: Option<bool>,
 
     // Gradual sync settings
+    /// Gradual-source sync mode.
     pub gradual_src_mode: Option<String>,
+    /// Maximum number of sources synced concurrently in gradual mode.
     pub gradual_src_max_sources: Option<u32>,
+    /// Gradual sync mode.
     pub gradual_sync_mode: Option<String>,
+    /// Maximum number of shards synced concurrently per source in gradual mode.
     pub gradual_sync_max_shards_per_source: Option<u32>,
 
     // Slave and buffer settings
+    /// Replica output buffer limits.
     pub slave_buffer: Option<String>,
 
     // Snapshot settings
+    /// Snapshot policy entries (RDB save points).
     pub snapshot_policy: Option<Vec<Value>>,
 
     // Scheduling and recovery
+    /// Proxy scheduling policy (e.g. `"cmp"`, `"mnp"`, `"mru"`).
     pub sched_policy: Option<String>,
+    /// Seconds to wait before automatic recovery (negative disables).
     pub recovery_wait_time: Option<i32>,
 
     // Performance and optimization
+    /// MULTI command optimization mode.
     pub multi_commands_opt: Option<String>,
+    /// Configured ingress throughput cap.
     pub throughput_ingress: Option<f64>,
+    /// Maximum number of keys tracked by the client-side caching tracking table.
     pub tracking_table_max_keys: Option<u32>,
+    /// Whether the WAIT command is allowed.
     pub wait_command: Option<bool>,
 
     // Legacy and deprecated fields
+    /// Background operations currently running on the database (read-only).
     pub background_op: Option<Vec<Value>>,
 
     // Advanced configuration
+    /// Whether MKMS (multi-key multi-slot) commands are allowed.
     pub mkms: Option<bool>,
+    /// Role-based permissions for the database.
     pub roles_permissions: Option<Vec<Value>>,
+    /// Free-form tags attached to the database.
     pub tags: Option<Vec<String>>,
+    /// Current topology epoch counter (read-only).
     pub topology_epoch: Option<u32>,
 }
 
@@ -461,8 +615,10 @@ pub struct EndpointInfo {
 /// Module configuration for database creation
 #[derive(Debug, Clone, Serialize, Deserialize, TypedBuilder)]
 pub struct ModuleConfig {
+    /// Module name to load (e.g. `"search"`, `"timeseries"`, `"bf"`).
     #[builder(setter(into))]
     pub module_name: String,
+    /// Arguments passed to the module when it loads.
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(default, setter(into, strip_option))]
     pub module_args: Option<String>,
@@ -488,44 +644,58 @@ pub struct ModuleConfig {
 /// ```
 #[derive(Debug, Serialize, Deserialize, TypedBuilder)]
 pub struct CreateDatabaseRequest {
+    /// Database name.
     #[builder(setter(into))]
     pub name: String,
+    /// Database memory limit in bytes (0 for unlimited).
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(default, setter(strip_option))]
     pub memory_size: Option<u64>,
+    /// TCP port on which the database is available (read-only).
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(default, setter(strip_option))]
     pub port: Option<u16>,
+    /// Whether in-memory replication is enabled.
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(default, setter(strip_option))]
     pub replication: Option<bool>,
+    /// Persistence policy (e.g. `"disabled"`, `"aof"`, `"snapshot"`).
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(default, setter(into, strip_option))]
     pub persistence: Option<String>,
+    /// Eviction policy when the database reaches its memory limit (e.g. `"allkeys-lru"`).
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(default, setter(into, strip_option))]
     pub eviction_policy: Option<String>,
+    /// Whether the database is sharded.
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(default, setter(strip_option))]
     pub sharding: Option<bool>,
+    /// Number of database shards.
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(default, setter(strip_option))]
     pub shards_count: Option<u32>,
+    /// Shard count.
     #[serde(skip_serializing_if = "Option::is_none", alias = "shard_count")]
     #[builder(default, setter(strip_option))]
     pub shard_count: Option<u32>,
+    /// Proxy policy (e.g. `"single"`, `"all-master-shards"`, `"all-nodes"`).
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(default, setter(into, strip_option))]
     pub proxy_policy: Option<String>,
+    /// Whether rack-aware shard placement is enabled.
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(default, setter(strip_option))]
     pub rack_aware: Option<bool>,
+    /// List of Redis modules loaded into the database.
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(default, setter(strip_option))]
     pub module_list: Option<Vec<ModuleConfig>>,
+    /// Whether this database participates in a CRDT (Active-Active) deployment.
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(default, setter(strip_option))]
     pub crdt: Option<bool>,
+    /// Redis password used for client authentication.
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(default, setter(into, strip_option))]
     pub authentication_redis_pass: Option<String>,
@@ -537,6 +707,7 @@ pub struct DatabaseHandler {
 }
 
 impl DatabaseHandler {
+    /// New.
     pub fn new(client: RestClient) -> Self {
         DatabaseHandler { client }
     }

--- a/src/bdb_groups.rs
+++ b/src/bdb_groups.rs
@@ -42,6 +42,7 @@ pub struct BdbGroupsHandler {
 }
 
 impl BdbGroupsHandler {
+    /// Create a new handler bound to the given REST client.
     pub fn new(client: RestClient) -> Self {
         BdbGroupsHandler { client }
     }
@@ -56,20 +57,24 @@ impl BdbGroupsHandler {
         Ok(resp.bdb_groups)
     }
 
+    /// Get a single database group by UID.
     pub async fn get(&self, uid: u32) -> Result<BdbGroup> {
         self.client.get(&format!("/v1/bdb_groups/{}", uid)).await
     }
 
+    /// Create a new database group.
     pub async fn create(&self, body: CreateBdbGroupRequest) -> Result<BdbGroup> {
         self.client.post("/v1/bdb_groups", &body).await
     }
 
+    /// Update an existing database group.
     pub async fn update(&self, uid: u32, body: UpdateBdbGroupRequest) -> Result<BdbGroup> {
         self.client
             .put(&format!("/v1/bdb_groups/{}", uid), &body)
             .await
     }
 
+    /// Delete a database group.
     pub async fn delete(&self, uid: u32) -> Result<()> {
         self.client.delete(&format!("/v1/bdb_groups/{}", uid)).await
     }
@@ -78,12 +83,14 @@ impl BdbGroupsHandler {
 /// Request to create a new database group
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CreateBdbGroupRequest {
+    /// Name.
     pub name: String,
 }
 
 /// Request to update an existing database group
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct UpdateBdbGroupRequest {
+    /// Name.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
 }

--- a/src/bootstrap.rs
+++ b/src/bootstrap.rs
@@ -146,6 +146,7 @@ pub struct BootstrapHandler {
 }
 
 impl BootstrapHandler {
+    /// Create a new handler bound to the given REST client.
     pub fn new(client: RestClient) -> Self {
         BootstrapHandler { client }
     }

--- a/src/client.rs
+++ b/src/client.rs
@@ -43,6 +43,7 @@ use tracing::{debug, trace};
 const DEFAULT_USER_AGENT: &str = concat!("redis-enterprise/", env!("CARGO_PKG_VERSION"));
 
 // Legacy alias for backwards compatibility during migration
+/// Legacy alias for [`EnterpriseClientBuilder`]; retained for backwards compatibility.
 pub type RestConfig = EnterpriseClientBuilder;
 
 /// Builder for EnterpriseClient
@@ -247,6 +248,7 @@ pub struct EnterpriseClient {
 }
 
 // Alias for backwards compatibility
+/// Alias for [`EnterpriseClient`]; retained for backwards compatibility.
 pub type RestClient = EnterpriseClient;
 
 impl EnterpriseClient {

--- a/src/cluster.rs
+++ b/src/cluster.rs
@@ -61,12 +61,19 @@ pub struct ClusterActionResponse {
 /// Node information
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ClusterNode {
+    /// Node ID.
     pub id: u32,
+    /// Node address (hostname or IP).
     pub address: String,
+    /// Node status.
     pub status: String,
+    /// Node role (e.g. `"master"`, `"slave"`).
     pub role: Option<String>,
+    /// Total memory available on the node in bytes.
     pub total_memory: Option<u64>,
+    /// Used memory on the node in bytes.
     pub used_memory: Option<u64>,
+    /// Number of CPU cores on the node.
     pub cpu_cores: Option<u32>,
 }
 
@@ -339,8 +346,11 @@ pub struct ClusterSettings {
 
     /// BigStore migration thresholds
     pub bigstore_migrate_node_threshold: Option<u32>,
+    /// Percent threshold for BigStore node migration.
     pub bigstore_migrate_node_threshold_p: Option<u32>,
+    /// Bytes threshold for BigStore node provisioning.
     pub bigstore_provision_node_threshold: Option<u32>,
+    /// Percent threshold for BigStore node provisioning.
     pub bigstore_provision_node_threshold_p: Option<u32>,
 
     /// Default BigStore version
@@ -360,10 +370,12 @@ pub struct ClusterSettings {
 
     /// Default proxy policies
     pub default_non_sharded_proxy_policy: Option<String>,
+    /// Default proxy policy for sharded databases.
     pub default_sharded_proxy_policy: Option<String>,
 
     /// OSS cluster defaults
     pub default_oss_cluster: Option<bool>,
+    /// Default OSS-style hash-slot sharding setting for new databases.
     pub default_oss_sharding: Option<bool>,
 
     /// Default Redis version for new databases
@@ -380,40 +392,64 @@ pub struct ClusterSettings {
 
     /// Additional cluster-wide settings
     pub email_alerts: Option<bool>,
+    /// Whether endpoint rebinding is enabled.
     pub endpoint_rebind_enabled: Option<bool>,
+    /// Failure detection sensitivity (e.g. `"low"`, `"high"`).
     pub failure_detection_sensitivity: Option<String>,
+    /// Gossip Envoy admin port.
     pub gossip_envoy_admin_port: Option<u32>,
+    /// Gossip Envoy listener port.
     pub gossip_envoy_port: Option<u32>,
+    /// Whether gossip uses Envoy proxy mode.
     pub gossip_envoy_proxy_mode: Option<bool>,
+    /// Whether hot-spare nodes are allowed.
     pub hot_spare: Option<bool>,
+    /// Maximum number of events retained per event type.
     pub max_saved_events_per_type: Option<u32>,
+    /// Maximum number of concurrent backups across the cluster.
     pub max_simultaneous_backups: Option<u32>,
+    /// Maximum number of shards upgraded in parallel.
     pub parallel_shards_upgrade: Option<u32>,
+    /// Whether removed nodes are persistently excluded.
     pub persistent_node_removal: Option<bool>,
+    /// Whether rack-aware shard placement is enabled.
     pub rack_aware: Option<bool>,
+    /// Bytes threshold for Redis node migration.
     pub redis_migrate_node_threshold: Option<String>,
+    /// Percent threshold for Redis node migration.
     pub redis_migrate_node_threshold_p: Option<u32>,
+    /// Bytes threshold for Redis node provisioning.
     pub redis_provision_node_threshold: Option<String>,
+    /// Percent threshold for Redis node provisioning.
     pub redis_provision_node_threshold_p: Option<u32>,
+    /// Cluster-wide Redis upgrade policy (e.g. `"major"`, `"latest"`).
     pub redis_upgrade_policy: Option<String>,
+    /// Whether RESP3 is enabled by default for new databases.
     pub resp3_default: Option<bool>,
+    /// Whether internal databases are shown in listings.
     pub show_internals: Option<bool>,
+    /// Whether master shards use slave I/O threads.
     pub slave_threads_when_master: Option<bool>,
+    /// Whether empty shards still produce backup snapshots.
     pub use_empty_shard_backups: Option<bool>,
 }
 
 /// Bootstrap request for creating a new cluster
 #[derive(Debug, Serialize, TypedBuilder)]
 pub struct BootstrapRequest {
+    /// Bootstrap action (e.g. `"create_cluster"`, `"join_cluster"`).
     #[builder(setter(into))]
     pub action: String,
+    /// Cluster identification used during bootstrap. See [`ClusterBootstrapInfo`].
     pub cluster: ClusterBootstrapInfo,
+    /// Credentials used during bootstrap. See [`BootstrapCredentials`].
     pub credentials: BootstrapCredentials,
 }
 
 /// Cluster information for bootstrap
 #[derive(Debug, Serialize, TypedBuilder)]
 pub struct ClusterBootstrapInfo {
+    /// Cluster name (fully qualified domain name).
     #[builder(setter(into))]
     pub name: String,
 }
@@ -421,8 +457,10 @@ pub struct ClusterBootstrapInfo {
 /// Credentials for bootstrap
 #[derive(Debug, Serialize, TypedBuilder)]
 pub struct BootstrapCredentials {
+    /// Admin username used during bootstrap.
     #[builder(setter(into))]
     pub username: String,
+    /// Admin password used during bootstrap.
     #[builder(setter(into))]
     pub password: String,
 }
@@ -433,6 +471,7 @@ pub struct ClusterHandler {
 }
 
 impl ClusterHandler {
+    /// New.
     pub fn new(client: RestClient) -> Self {
         ClusterHandler { client }
     }
@@ -652,21 +691,33 @@ impl ClusterHandler {
 /// Node information
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct NodeInfo {
+    /// Node's unique ID (read-only).
     pub uid: u32,
+    /// Node address (hostname or IP).
     pub address: String,
+    /// Node status.
     pub status: String,
+    /// Node role (e.g. `"master"`, `"slave"`).
     pub role: Option<String>,
+    /// List of shard UIDs hosted on this node (read-only).
     pub shards: Option<Vec<u32>>,
+    /// Total memory available on the node in bytes.
     pub total_memory: Option<u64>,
+    /// Used memory on the node in bytes.
     pub used_memory: Option<u64>,
 }
 
 /// License information
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct LicenseInfo {
+    /// License type (e.g. `"production"`, `"trial"`).
     pub license_type: Option<String>,
+    /// Whether the license has expired.
     pub expired: Option<bool>,
+    /// License expiration date (ISO-8601).
     pub expiration_date: Option<String>,
+    /// Maximum number of shards permitted by the license.
     pub shards_limit: Option<u32>,
+    /// List of licensed feature names.
     pub features: Option<Vec<String>>,
 }

--- a/src/cm_settings.rs
+++ b/src/cm_settings.rs
@@ -41,6 +41,7 @@ pub struct CmSettingsHandler {
 }
 
 impl CmSettingsHandler {
+    /// Create a new handler bound to the given REST client.
     pub fn new(client: RestClient) -> Self {
         CmSettingsHandler { client }
     }

--- a/src/crdb.rs
+++ b/src/crdb.rs
@@ -137,6 +137,7 @@ pub struct CrdbHandler {
 }
 
 impl CrdbHandler {
+    /// Create a new handler bound to the given REST client.
     pub fn new(client: RestClient) -> Self {
         CrdbHandler { client }
     }

--- a/src/crdb_tasks.rs
+++ b/src/crdb_tasks.rs
@@ -57,6 +57,7 @@ pub struct CrdbTasksHandler {
 }
 
 impl CrdbTasksHandler {
+    /// Create a new handler bound to the given REST client.
     pub fn new(client: RestClient) -> Self {
         CrdbTasksHandler { client }
     }

--- a/src/debuginfo.rs
+++ b/src/debuginfo.rs
@@ -73,6 +73,7 @@ pub struct DebugInfoHandler {
 }
 
 impl DebugInfoHandler {
+    /// Create a new handler bound to the given REST client.
     pub fn new(client: RestClient) -> Self {
         DebugInfoHandler { client }
     }

--- a/src/diagnostics.rs
+++ b/src/diagnostics.rs
@@ -79,6 +79,7 @@ pub struct DiagnosticsHandler {
 }
 
 impl DiagnosticsHandler {
+    /// Create a new handler bound to the given REST client.
     pub fn new(client: RestClient) -> Self {
         DiagnosticsHandler { client }
     }

--- a/src/endpoints.rs
+++ b/src/endpoints.rs
@@ -13,17 +13,26 @@ use serde_json::Value;
 /// Endpoint information
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Endpoint {
+    /// Unique identifier (read-only).
     pub uid: String,
+    /// Database (BDB) UID this entity belongs to.
     pub bdb_uid: u32,
+    /// Node UID this entity belongs to.
     pub node_uid: u32,
+    /// Address.
     pub addr: String,
+    /// TCP port.
     pub port: u16,
+    /// DNS name.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub dns_name: Option<String>,
+    /// Role.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub role: Option<String>,
+    /// Whether SSL/TLS is enabled.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub ssl: Option<bool>,
+    /// Current status.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub status: Option<String>,
     /// Description of the endpoint
@@ -37,14 +46,20 @@ pub struct Endpoint {
 /// Endpoint statistics
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct EndpointStats {
+    /// Unique identifier (read-only).
     pub uid: String,
+    /// Per-interval metric series for the resource.
     pub intervals: Vec<StatsInterval>,
 }
 
+/// One interval of statistics, with aligned timestamps and values.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct StatsInterval {
+    /// Interval label for the metric series.
     pub interval: String,
+    /// List of Unix-epoch timestamps for the data points.
     pub timestamps: Vec<i64>,
+    /// List of metric values, aligned to `timestamps`.
     pub values: Vec<Value>,
 }
 
@@ -54,6 +69,7 @@ pub struct EndpointsHandler {
 }
 
 impl EndpointsHandler {
+    /// Create a new handler bound to the given REST client.
     pub fn new(client: RestClient) -> Self {
         EndpointsHandler { client }
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -3,59 +3,86 @@
 use std::time::Duration;
 use thiserror::Error;
 
+/// Errors returned by Redis Enterprise REST API operations.
 #[derive(Error, Debug, Clone)]
 pub enum RestError {
+    /// The provided base URL could not be parsed.
     #[error("Invalid URL: {0}")]
     InvalidUrl(String),
 
+    /// The underlying HTTP request failed (network or transport error).
     #[error("HTTP request failed: {0}")]
     RequestFailed(String),
 
+    /// Authentication failed (invalid credentials).
     #[error("Authentication failed")]
     AuthenticationFailed,
 
+    /// The server returned a structured API error with HTTP status code.
     #[error("API error: {message} (code: {code})")]
-    ApiError { code: u16, message: String },
+    ApiError {
+        /// HTTP status code returned by the server.
+        code: u16,
+        /// Server-provided error message.
+        message: String,
+    },
 
+    /// Request or response could not be serialized/deserialized.
     #[error("Serialization error: {0}")]
     SerializationError(String),
 
+    /// Response could not be parsed into the expected shape.
     #[error("Parse error: {0}")]
     ParseError(String),
 
+    /// Could not establish a connection to the REST API.
     #[error("Connection error: {0}")]
     ConnectionError(String),
 
+    /// TLS handshake or certificate validation failed.
     #[error("TLS certificate error: {0}")]
     TlsError(String),
 
+    /// Client has not been connected to the REST API yet.
     #[error("Not connected to REST API")]
     NotConnected,
 
+    /// Client-side validation of input parameters failed.
     #[error("Validation error: {0}")]
     ValidationError(String),
 
+    /// The requested resource was not found (HTTP 404).
     #[error("Resource not found")]
     NotFound,
 
+    /// The request was unauthorized (HTTP 401).
     #[error("Unauthorized")]
     Unauthorized,
 
+    /// The server returned a 5xx error.
     #[error("Server error: {0}")]
     ServerError(String),
 
+    /// The request timed out.
     #[error("Request timed out")]
     Timeout,
 
+    /// The client has been rate limited by the server (HTTP 429).
     #[error("Rate limited{}", .retry_after.map(|d| format!(" (retry after {:?})", d)).unwrap_or_default())]
-    RateLimited { retry_after: Option<Duration> },
+    RateLimited {
+        /// Optional retry-after duration suggested by the server.
+        retry_after: Option<Duration>,
+    },
 
+    /// The resource already exists (HTTP 409).
     #[error("Resource already exists")]
     AlreadyExists,
 
+    /// A conflict occurred while processing the request (HTTP 409).
     #[error("Conflict: {0}")]
     Conflict(String),
 
+    /// The cluster is busy or temporarily unavailable (HTTP 503).
     #[error("Cluster is busy or unavailable")]
     ClusterBusy,
 }
@@ -131,4 +158,5 @@ impl RestError {
     }
 }
 
+/// Result alias used throughout the crate for Redis Enterprise REST API operations.
 pub type Result<T> = std::result::Result<T, RestError>;

--- a/src/jsonschema.rs
+++ b/src/jsonschema.rs
@@ -15,6 +15,7 @@ pub struct JsonSchemaHandler {
 }
 
 impl JsonSchemaHandler {
+    /// Create a new handler bound to the given REST client.
     pub fn new(client: RestClient) -> Self {
         JsonSchemaHandler { client }
     }

--- a/src/license.rs
+++ b/src/license.rs
@@ -106,6 +106,7 @@ pub struct LicenseHandler {
 }
 
 impl LicenseHandler {
+    /// Create a new handler bound to the given REST client.
     pub fn new(client: RestClient) -> Self {
         LicenseHandler { client }
     }

--- a/src/local.rs
+++ b/src/local.rs
@@ -9,11 +9,13 @@ use crate::client::RestClient;
 use crate::error::Result;
 use serde_json::Value;
 
+/// Handler for local-node operations (`/v1/local/...`).
 pub struct LocalHandler {
     client: RestClient,
 }
 
 impl LocalHandler {
+    /// Create a new handler bound to the given REST client.
     pub fn new(client: RestClient) -> Self {
         LocalHandler { client }
     }

--- a/src/logs.rs
+++ b/src/logs.rs
@@ -52,6 +52,7 @@ pub struct LogsHandler {
 }
 
 impl LogsHandler {
+    /// Create a new handler bound to the given REST client.
     pub fn new(client: RestClient) -> Self {
         LogsHandler { client }
     }

--- a/src/migrations.rs
+++ b/src/migrations.rs
@@ -85,6 +85,7 @@ pub struct MigrationsHandler {
 }
 
 impl MigrationsHandler {
+    /// Create a new handler bound to the given REST client.
     pub fn new(client: RestClient) -> Self {
         MigrationsHandler { client }
     }

--- a/src/modules.rs
+++ b/src/modules.rs
@@ -25,19 +25,33 @@ pub struct PlatformInfo {
 /// Module information
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Module {
+    /// Unique identifier (read-only).
     pub uid: String,
+    /// Module name (e.g. `"search"`, `"timeseries"`).
     pub module_name: Option<String>,
+    /// Version (read-only).
     pub version: Option<u32>,
+    /// Semantic version string.
     pub semantic_version: Option<String>,
+    /// Author name.
     pub author: Option<String>,
+    /// Human-readable description.
     pub description: Option<String>,
+    /// Homepage URL.
     pub homepage: Option<String>,
+    /// License identifier.
     pub license: Option<String>,
+    /// Default command-line arguments.
     pub command_line_args: Option<String>,
+    /// List of module capabilities.
     pub capabilities: Option<Vec<String>>,
+    /// Minimum compatible Redis version.
     pub min_redis_version: Option<String>,
+    /// Compatible Redis version range.
     pub compatible_redis_version: Option<String>,
+    /// Display name shown in the UI.
     pub display_name: Option<String>,
+    /// Whether the module is bundled with Redis Enterprise.
     pub is_bundled: Option<bool>,
 
     // Additional fields from API audit
@@ -82,6 +96,7 @@ pub struct ModuleHandler {
 pub type ModulesHandler = ModuleHandler;
 
 impl ModuleHandler {
+    /// Create a new handler bound to the given REST client.
     pub fn new(client: RestClient) -> Self {
         ModuleHandler { client }
     }

--- a/src/nodes.rs
+++ b/src/nodes.rs
@@ -124,22 +124,33 @@ pub struct Node {
 /// Node stats
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct NodeStats {
+    /// Unique identifier (read-only).
     pub uid: u32,
+    /// User-mode CPU time fraction.
     pub cpu_user: Option<f64>,
+    /// System-mode CPU time fraction.
     pub cpu_system: Option<f64>,
+    /// Idle CPU time fraction.
     pub cpu_idle: Option<f64>,
+    /// Free memory in bytes.
     pub free_memory: Option<u64>,
+    /// Incoming network bytes.
     pub network_bytes_in: Option<u64>,
+    /// Outgoing network bytes.
     pub network_bytes_out: Option<u64>,
+    /// Free persistent storage in bytes.
     pub persistent_storage_free: Option<u64>,
+    /// Free ephemeral storage in bytes.
     pub ephemeral_storage_free: Option<u64>,
 }
 
 /// Node action request
 #[derive(Debug, Serialize, TypedBuilder)]
 pub struct NodeActionRequest {
+    /// Action name to execute.
     #[builder(setter(into))]
     pub action: String,
+    /// Node UID this entity belongs to.
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(default, setter(strip_option))]
     pub node_uid: Option<u32>,
@@ -154,6 +165,7 @@ pub struct NodeHandler {
 pub type NodesHandler = NodeHandler;
 
 impl NodeHandler {
+    /// Create a new handler bound to the given REST client.
     pub fn new(client: RestClient) -> Self {
         NodeHandler { client }
     }

--- a/src/ocsp.rs
+++ b/src/ocsp.rs
@@ -73,6 +73,7 @@ pub struct OcspHandler {
 }
 
 impl OcspHandler {
+    /// Create a new handler bound to the given REST client.
     pub fn new(client: RestClient) -> Self {
         OcspHandler { client }
     }

--- a/src/proxies.rs
+++ b/src/proxies.rs
@@ -13,8 +13,11 @@ use serde_json::Value;
 /// Response for a single metric query
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct MetricResponse {
+    /// Interval label for the metric series.
     pub interval: String,
+    /// List of Unix-epoch timestamps for the data points.
     pub timestamps: Vec<i64>,
+    /// List of metric values, aligned to `timestamps`.
     pub values: Vec<Value>,
 }
 
@@ -40,12 +43,16 @@ pub struct Proxy {
     /// Current proxy status (e.g. `"active"`, `"deactivated"`).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub status: Option<String>,
+    /// Address.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub addr: Option<String>,
+    /// TCP port.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub port: Option<u16>,
+    /// Maximum number of client connections.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub max_connections: Option<u32>,
+    /// Number of worker threads.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub threads: Option<u32>,
 
@@ -150,14 +157,20 @@ pub struct Proxy {
 /// Proxy stats information
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ProxyStats {
+    /// Unique identifier (read-only).
     pub uid: u32,
+    /// Per-interval metric series for the resource.
     pub intervals: Vec<StatsInterval>,
 }
 
+/// One interval of statistics, with aligned timestamps and values.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct StatsInterval {
+    /// Interval label for the metric series.
     pub interval: String,
+    /// List of Unix-epoch timestamps for the data points.
     pub timestamps: Vec<i64>,
+    /// List of metric values, aligned to `timestamps`.
     pub values: Vec<Value>,
 }
 
@@ -167,6 +180,7 @@ pub struct ProxyHandler {
 }
 
 impl ProxyHandler {
+    /// Create a new handler bound to the given REST client.
     pub fn new(client: RestClient) -> Self {
         ProxyHandler { client }
     }
@@ -230,8 +244,10 @@ impl ProxyHandler {
 /// Proxy update body
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ProxyUpdate {
+    /// Maximum number of client connections.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub max_connections: Option<u32>,
+    /// Number of worker threads.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub threads: Option<u32>,
 }

--- a/src/redis_acls.rs
+++ b/src/redis_acls.rs
@@ -12,9 +12,13 @@ use typed_builder::TypedBuilder;
 /// Redis ACL information
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct RedisAcl {
+    /// Unique identifier (read-only).
     pub uid: u32,
+    /// Name.
     pub name: String,
+    /// Redis ACL definition string.
     pub acl: String,
+    /// Human-readable description.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
     /// List of database UIDs this ACL is associated with
@@ -25,10 +29,13 @@ pub struct RedisAcl {
 /// Create or update Redis ACL request
 #[derive(Debug, Serialize, Deserialize, TypedBuilder)]
 pub struct CreateRedisAclRequest {
+    /// Name.
     #[builder(setter(into))]
     pub name: String,
+    /// Redis ACL definition string.
     #[builder(setter(into))]
     pub acl: String,
+    /// Human-readable description.
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(default, setter(into, strip_option))]
     pub description: Option<String>,
@@ -58,9 +65,12 @@ impl RedisAclHandler {
     }
 }
 
+/// Result of validating a Redis ACL payload.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct AclValidation {
+    /// Whether the ACL is valid.
     pub valid: bool,
+    /// Validation message describing the result.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub message: Option<String>,
 }

--- a/src/roles.rs
+++ b/src/roles.rs
@@ -12,14 +12,20 @@ use typed_builder::TypedBuilder;
 /// Role information
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct RoleInfo {
+    /// Unique identifier (read-only).
     pub uid: u32,
+    /// Name.
     pub name: String,
+    /// Management permission level (e.g. `"admin"`, `"db_member"`).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub management: Option<String>,
+    /// Data access permission level.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub data_access: Option<String>,
+    /// Per-database role permissions. See [`BdbRole`].
     #[serde(skip_serializing_if = "Option::is_none")]
     pub bdb_roles: Option<Vec<BdbRole>>,
+    /// List of cluster-wide role names.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub cluster_roles: Option<Vec<String>>,
 }
@@ -27,9 +33,12 @@ pub struct RoleInfo {
 /// Database-specific role permissions
 #[derive(Debug, Clone, Serialize, Deserialize, TypedBuilder)]
 pub struct BdbRole {
+    /// Database (BDB) UID this entity belongs to.
     pub bdb_uid: u32,
+    /// Role.
     #[builder(setter(into))]
     pub role: String,
+    /// UID of the Redis ACL associated with this role binding.
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(default, setter(strip_option))]
     pub redis_acl_uid: Option<u32>,
@@ -55,17 +64,22 @@ pub struct BdbRole {
 /// ```
 #[derive(Debug, Clone, Serialize, Deserialize, TypedBuilder)]
 pub struct CreateRoleRequest {
+    /// Name.
     #[builder(setter(into))]
     pub name: String,
+    /// Management permission level (e.g. `"admin"`, `"db_member"`).
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(default, setter(into, strip_option))]
     pub management: Option<String>,
+    /// Data access permission level.
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(default, setter(into, strip_option))]
     pub data_access: Option<String>,
+    /// Per-database role permissions. See [`BdbRole`].
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(default, setter(strip_option))]
     pub bdb_roles: Option<Vec<BdbRole>>,
+    /// List of cluster-wide role names.
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(default, setter(strip_option))]
     pub cluster_roles: Option<Vec<String>>,

--- a/src/services.rs
+++ b/src/services.rs
@@ -81,6 +81,7 @@ pub struct ServicesHandler {
 }
 
 impl ServicesHandler {
+    /// Create a new handler bound to the given REST client.
     pub fn new(client: RestClient) -> Self {
         ServicesHandler { client }
     }

--- a/src/shards.rs
+++ b/src/shards.rs
@@ -13,25 +13,37 @@ use serde_json::Value;
 /// Response for a single metric query
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct MetricResponse {
+    /// Interval label for the metric series.
     pub interval: String,
+    /// List of Unix-epoch timestamps for the data points.
     pub timestamps: Vec<i64>,
+    /// List of metric values, aligned to `timestamps`.
     pub values: Vec<Value>,
 }
 
 /// Shard information
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Shard {
+    /// Unique identifier (read-only).
     pub uid: String,
+    /// Database (BDB) UID this entity belongs to.
     pub bdb_uid: u32,
+    /// Node UID this entity belongs to.
     pub node_uid: String,
+    /// Role.
     pub role: String,
+    /// Current status.
     pub status: String,
+    /// Hash slot range owned by this shard.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub slots: Option<String>,
+    /// Used memory in bytes.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub used_memory: Option<u64>,
+    /// Percent progress (0-100) of in-flight backup.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub backup_progress: Option<f64>,
+    /// Percent progress (0-100) of in-flight import.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub import_progress: Option<f64>,
     /// All nodes that this shard is associated with
@@ -49,14 +61,20 @@ pub struct Shard {
 /// Shard stats information
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ShardStats {
+    /// Unique identifier (read-only).
     pub uid: String,
+    /// Per-interval metric series for the resource.
     pub intervals: Vec<StatsInterval>,
 }
 
+/// One interval of statistics, with aligned timestamps and values.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct StatsInterval {
+    /// Interval label for the metric series.
     pub interval: String,
+    /// List of Unix-epoch timestamps for the data points.
     pub timestamps: Vec<i64>,
+    /// List of metric values, aligned to `timestamps`.
     pub values: Vec<Value>,
 }
 
@@ -66,6 +84,7 @@ pub struct ShardHandler {
 }
 
 impl ShardHandler {
+    /// Create a new handler bound to the given REST client.
     pub fn new(client: RestClient) -> Self {
         ShardHandler { client }
     }
@@ -135,15 +154,20 @@ impl ShardHandler {
     }
 }
 
+/// Request body for shard action endpoints (failover, migrate).
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ShardActionRequest {
+    /// List of shard UIDs targeted by this action.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub shard_uids: Option<Vec<String>>,
 }
 
+/// Response from a shard action endpoint with the tracking UID.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Action {
+    /// Action UID for tracking async operations (read-only).
     pub action_uid: String,
+    /// Current status.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub status: Option<String>,
 }

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -189,6 +189,7 @@ pub struct StatsHandler {
 }
 
 impl StatsHandler {
+    /// Create a new handler bound to the given REST client.
     pub fn new(client: RestClient) -> Self {
         StatsHandler { client }
     }

--- a/src/suffixes.rs
+++ b/src/suffixes.rs
@@ -51,6 +51,7 @@ pub struct SuffixesHandler {
 }
 
 impl SuffixesHandler {
+    /// Create a new handler bound to the given REST client.
     pub fn new(client: RestClient) -> Self {
         SuffixesHandler { client }
     }

--- a/src/types.rs
+++ b/src/types.rs
@@ -6,148 +6,226 @@ use serde_json::Value;
 /// Database group - represents a group of databases sharing a memory pool
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct BdbGroup {
+    /// Unique identifier (read-only).
     pub uid: u32,
+    /// Memory pool size in bytes.
     pub memory_size: u64,
+    /// List of member database UIDs.
     pub members: Vec<u32>,
 }
 
 /// Database connections auditing configuration
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct DbConnsAuditingConfig {
+    /// Audit protocol (e.g. `"TCP"`, `"syslog"`).
     pub audit_protocol: String,
+    /// Audit collector address.
     pub audit_address: String,
+    /// Audit collector port.
     pub audit_port: u16,
+    /// Reconnect interval in seconds.
     pub audit_reconnect_interval: Option<u32>,
+    /// Maximum number of reconnect attempts.
     pub audit_reconnect_max_attempts: Option<u32>,
 }
 
 /// Cluster check result for diagnostics
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CheckResult {
+    /// Overall cluster test result (e.g. `"PASS"`, `"FAIL"`).
     pub cluster_test_result: Option<String>,
+    /// Per-node check results. See [`NodeCheckResult`].
     pub nodes: Option<Vec<NodeCheckResult>>,
 }
 
 /// Node check result for diagnostics
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct NodeCheckResult {
+    /// Node UID.
     pub node_uid: u32,
+    /// Check status.
     pub status: String,
+    /// List of individual checks performed on the node.
     pub checks: Option<Vec<Value>>,
 }
 
 /// Services configuration
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ServicesConfiguration {
+    /// Cluster manager (CM) server configuration. See [`ServiceConfig`].
     pub cm_server: Option<ServiceConfig>,
+    /// CRDB coordinator configuration. See [`ServiceConfig`].
     pub crdb_coordinator: Option<ServiceConfig>,
+    /// CRDB worker configuration. See [`ServiceConfig`].
     pub crdb_worker: Option<ServiceConfig>,
+    /// mDNS server configuration. See [`ServiceConfig`].
     pub mdns_server: Option<ServiceConfig>,
+    /// PowerDNS server configuration. See [`ServiceConfig`].
     pub pdns_server: Option<ServiceConfig>,
+    /// Redis server configuration. See [`ServiceConfig`].
     pub redis_server: Option<ServiceConfig>,
+    /// saslauthd service configuration. See [`ServiceConfig`].
     pub saslauthd: Option<ServiceConfig>,
+    /// Stats archiver service configuration. See [`ServiceConfig`].
     pub stats_archiver: Option<ServiceConfig>,
 }
 
 /// Individual service configuration
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ServiceConfig {
+    /// Whether the service is enabled.
     pub enabled: bool,
+    /// Port the service listens on.
     pub port: Option<u16>,
+    /// Service-specific settings (free-form).
     pub settings: Option<Value>,
 }
 
 /// OCSP (Online Certificate Status Protocol) configuration
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct OcspConfig {
+    /// OCSP responder URL.
     pub ocsp_url: String,
+    /// OCSP response timeout in seconds.
     pub ocsp_response_timeout_seconds: Option<u32>,
+    /// OCSP query frequency in seconds.
     pub query_frequency_seconds: Option<u32>,
+    /// OCSP recovery query frequency in seconds.
     pub recovery_frequency_seconds: Option<u32>,
+    /// Maximum number of OCSP recovery attempts.
     pub recovery_max_tries: Option<u32>,
+    /// OCSP responder certificate (PEM).
     pub responder_cert: Option<String>,
 }
 
 /// OCSP status information
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct OcspStatus {
+    /// Name of the certificate.
     pub cert_name: String,
+    /// OCSP status (e.g. `"good"`, `"revoked"`).
     pub ocsp_status: String,
+    /// Timestamp when the OCSP response was produced (ISO-8601).
     pub produced_at: Option<String>,
+    /// URL of the OCSP responder.
     pub responder_url: Option<String>,
+    /// Timestamp of the current update (ISO-8601).
     pub this_update: Option<String>,
+    /// Timestamp of the next scheduled update (ISO-8601).
     pub next_update: Option<String>,
 }
 
 /// JWT authorization configuration
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct JwtAuthorize {
+    /// JSON Web Key Set (JWKS) URI used to verify JWTs.
     pub jwks_uri: String,
 }
 
 /// State machine status (for long-running operations)
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct StateMachine {
+    /// State machine ID.
     pub id: String,
+    /// State machine name.
     pub name: String,
+    /// Current state.
     pub state: String,
+    /// Check status.
     pub status: String,
+    /// Percent progress (0–100).
     pub progress: Option<f64>,
+    /// Creation timestamp (ISO-8601).
     pub created: Option<String>,
+    /// Last update timestamp (ISO-8601).
     pub updated: Option<String>,
+    /// Error message if the state machine failed.
     pub error: Option<String>,
 }
 
 /// Module metadata information
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ModuleMetadata {
+    /// State machine name.
     pub name: String,
+    /// Module version.
     pub version: String,
+    /// Semantic version string.
     pub semantic_version: Option<String>,
+    /// Minimum compatible Redis version.
     pub min_redis_version: Option<String>,
+    /// Minimum compatible Redis Enterprise version.
     pub min_redis_pack_version: Option<String>,
+    /// List of capability names exposed by the module.
     pub capabilities: Option<Vec<String>>,
+    /// Default command-line arguments.
     pub command_line_args: Option<String>,
+    /// Configuration command exposed by the module.
     pub config_command: Option<String>,
+    /// List of module dependencies.
     pub dependencies: Option<Vec<String>>,
+    /// Human-readable description.
     pub description: Option<String>,
+    /// Display name shown in the UI.
     pub display_name: Option<String>,
+    /// Maintainer email address.
     pub email: Option<String>,
+    /// Module homepage URL.
     pub homepage: Option<String>,
+    /// Whether the module ships bundled with Redis Enterprise.
     pub is_bundled: Option<bool>,
+    /// Module license identifier.
     pub license: Option<String>,
+    /// Supported operating systems.
     pub os_list: Option<Vec<String>>,
+    /// SHA-256 checksum of the module package.
     pub sha256: Option<String>,
+    /// Unique identifier (read-only).
     pub uid: Option<String>,
+    /// Supported CPU architectures.
     pub architecture_list: Option<Vec<String>>,
+    /// Module author name.
     pub author: Option<String>,
 }
 
 /// Database command statistics
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct DbCommand {
+    /// Redis command name.
     pub command: String,
+    /// Number of times the command has been executed.
     pub count: u64,
 }
 
 /// Action v2 - enhanced action tracking
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ActionV2 {
+    /// Action unique identifier (read-only).
     pub action_uid: String,
+    /// State machine name.
     pub name: String,
+    /// Action type (e.g. `"backup"`, `"restore"`).
     pub action_type: String,
+    /// Unix-epoch timestamp when the action was created.
     pub creation_time: u64,
+    /// Percent progress (0–100).
     pub progress: f64,
+    /// Check status.
     pub status: String,
+    /// Additional action information. See [`ActionAdditionalInfo`].
     pub additional_info: Option<ActionAdditionalInfo>,
 }
 
 /// Additional info for ActionV2
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ActionAdditionalInfo {
+    /// Human-readable description.
     pub description: Option<String>,
+    /// Error message if the state machine failed.
     pub error: Option<String>,
+    /// Type of object the action operates on (e.g. `"bdb"`, `"node"`).
     pub object_type: Option<String>,
+    /// UID of the object the action operates on.
     pub object_uid: Option<String>,
 }
 

--- a/src/usage_report.rs
+++ b/src/usage_report.rs
@@ -111,6 +111,7 @@ pub struct UsageReportHandler {
 }
 
 impl UsageReportHandler {
+    /// Create a new handler bound to the given REST client.
     pub fn new(client: RestClient) -> Self {
         UsageReportHandler { client }
     }

--- a/src/users.rs
+++ b/src/users.rs
@@ -18,6 +18,7 @@ use typed_builder::TypedBuilder;
 /// User information
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct User {
+    /// Unique identifier (read-only).
     pub uid: u32,
     /// User's email address (used as login identifier) - was incorrectly named 'username'
     pub email: String,
@@ -151,9 +152,13 @@ pub struct UpdateUserRequest {
 /// Role information
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Role {
+    /// Unique identifier (read-only).
     pub uid: u32,
+    /// Name.
     pub name: String,
+    /// Management permission level (e.g. `"admin"`, `"db_member"`).
     pub management: Option<String>,
+    /// Data access permission level.
     pub data_access: Option<String>,
 }
 
@@ -166,6 +171,7 @@ pub struct UserHandler {
 pub type UsersHandler = UserHandler;
 
 impl UserHandler {
+    /// Create a new handler bound to the given REST client.
     pub fn new(client: RestClient) -> Self {
         UserHandler { client }
     }
@@ -252,40 +258,57 @@ impl UserHandler {
     }
 }
 
+/// Request body for `POST /v1/users/authorize` (user login).
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct AuthRequest {
+    /// Email address (used as login identifier).
     pub email: String,
+    /// Password.
     pub password: String,
 }
 
+/// Response from `POST /v1/users/authorize` containing the issued JWT.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct AuthResponse {
+    /// Encoded JWT.
     pub jwt: String,
+    /// Expiration timestamp (ISO-8601).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub expires_at: Option<String>,
 }
 
+/// Request body for `POST /v1/users/password` (set a user's password).
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PasswordSet {
+    /// Email address (used as login identifier).
     pub email: String,
+    /// Password.
     pub password: String,
 }
 
+/// Request body for `PUT /v1/users/password` (update a user's password).
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PasswordUpdate {
+    /// Current password (required for self-service password change).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub current_password: Option<String>,
+    /// New password.
     pub new_password: String,
 }
 
+/// Request body for `POST /v1/users/refresh_jwt`.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct JwtRefreshRequest {
+    /// Encoded JWT.
     pub jwt: String,
 }
 
+/// Response from `POST /v1/users/refresh_jwt` containing the new JWT.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct JwtRefreshResponse {
+    /// Encoded JWT.
     pub jwt: String,
+    /// Expiration timestamp (ISO-8601).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub expires_at: Option<String>,
 }
@@ -296,6 +319,7 @@ pub struct RoleHandler {
 }
 
 impl RoleHandler {
+    /// Create a new handler bound to the given REST client.
     pub fn new(client: RestClient) -> Self {
         RoleHandler { client }
     }


### PR DESCRIPTION
## Summary

Mechanical rustdoc pass that adds one-line documentation to previously-undocumented public items so that `cargo doc --no-deps --workspace` under `RUSTDOCFLAGS=\"-D missing_docs -D rustdoc::broken_intra_doc_links\"` produces zero errors.

**Before:** 490 `missing_docs` errors
**After:** 0

Docs-only — no struct, type, or wire-shape changes. The `#![deny(missing_docs)]` gate is intentionally **not** added in this PR; it will ship as a follow-up.

Refs #67. (Not `Closes #67` because the lint gate that closes the issue ships separately.)

## Style

Followed the conventions established in the cloud crate's #96:
- One short sentence per field, not a paragraph.
- Existing docstrings preserved unchanged — only empty ones filled in.
- Intra-doc links for nested struct field references (`See [\`Foo\`]`).
- Enum-like `Option<String>` fields mention common values inline.
- Boolean toggle fields: `\"Whether <feature> is enabled.\"`
- Timestamp fields: `\"... (ISO-8601).\"` / `\"Unix-epoch timestamp ...\"`
- `RestError` variants: one-sentence semantic description per variant.

## File-level breakdown

| File | Errors fixed |
|---|---|
| src/bdb.rs | 171 (primarily DatabaseInfo) |
| src/types.rs | 78 |
| src/cluster.rs | 51 |
| src/users.rs | 24 |
| src/shards.rs | 24 |
| src/error.rs | 23 (RestError variants + helpers) |
| src/proxies.rs | 16 |
| src/endpoints.rs | 16 |
| src/modules.rs | 15 |
| src/roles.rs | 14 |
| src/nodes.rs | 12 |
| src/redis_acls.rs | 10 |
| src/actions.rs | 8 |
| src/bdb_groups.rs | 7 |
| 18 other files | ~20 (handler constructors, type aliases) |

## Test plan

- [x] `RUSTDOCFLAGS=\"-D missing_docs -D rustdoc::broken_intra_doc_links\" cargo doc --no-deps --workspace` → 0 errors
- [x] `cargo fmt --all -- --check` → clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` → clean
- [x] `cargo test --workspace` → all green (no behavioural changes)

## Notes / anomalies

- `src/crdb.rs:109` has a `rustdoc::bare_urls` **warning** (not an error) — a doc comment contains a bare URL. Left alone as it's outside this PR's scope.
- `src/users.rs:9` has an \"empty Rust code block\" warning in the module-level docs. Same — out of scope.
- No suspected bugs found during the pass.