### PR TITLE
docs: enforce #![deny(missing_docs)] and rustdoc::broken_intra_doc_links

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -319,6 +319,11 @@
 //! - **Modules**: Redis module management
 //! - **Maintenance**: Upgrades, migrations, debug info
 
+// Every public item must carry a docstring. Closed the 490 existing
+// gaps under #67 (#85); this lint keeps the bar from regressing.
+#![deny(missing_docs)]
+#![deny(rustdoc::broken_intra_doc_links)]
+
 #[macro_use]
 mod macros;
 


### PR DESCRIPTION
## Summary

All 490 missing-docs errors surfaced by the 2026-05 review were closed in #85. This PR promotes both lints to compile errors so the bar can't regress without a deliberate decision.

```rust
#![deny(missing_docs)]
#![deny(rustdoc::broken_intra_doc_links)]
```

Mirrors what `redis-cloud-rs` did in [#98](https://github.com/redis-developer/redis-cloud-rs/pull/98) once that crate's missing-docs cleanup finished.

## How we got to zero

| PR | Slice | Errors closed |
|---|---|---|
| #85 | Mechanical pass across 32 files (agent-delegated) | 490 |
| **This** | Enforce lints | — |

`cargo doc --no-deps -- -D missing_docs -D rustdoc::broken_intra_doc_links` builds clean.

## Outstanding non-blocking warnings

Two `rustdoc` warnings remain (not errors, not blocked by the new lints):

- `src/crdb.rs:109` — bare URL in a docstring
- `src/users.rs:9` — empty Rust code block in the module-level docs

Both were flagged by the #85 agent as out of scope. Worth a small follow-up but doesn't gate this PR.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo doc --no-deps` (now strict by default)
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace` — all pass

Closes #67
