### PR TITLE
feat(cluster): add change_password_hashing_algorithm endpoint

### DIFF
--- a/src/cluster.rs
+++ b/src/cluster.rs
@@ -500,6 +500,23 @@ impl ClusterHandler {
         self.client.get("/v1/cluster/check").await
     }
 
+    /// Change the cluster's password hashing algorithm.
+    ///
+    /// `PATCH /v1/cluster/change_password_hashing_algorithm`. The request
+    /// body shape is intentionally `serde_json::Value` because the
+    /// documented payload is just a single `algorithm` field whose set of
+    /// accepted values is version-dependent and best left untyped. Send
+    /// something like `json!({"algorithm": "SHA-512"})`.
+    ///
+    /// Verified live against Redis Enterprise Software 8.0.10-81: an
+    /// empty body returns `400 empty_request`, confirming the route is
+    /// served by the cluster.
+    pub async fn change_password_hashing_algorithm(&self, body: Value) -> Result<Value> {
+        self.client
+            .patch_raw("/v1/cluster/change_password_hashing_algorithm", body)
+            .await
+    }
+
     /// Get cluster stats (CLUSTER.STATS)
     pub async fn stats(&self) -> Result<Value> {
         self.client.get("/v1/cluster/stats").await

--- a/tests/cluster_tests.rs
+++ b/tests/cluster_tests.rs
@@ -306,3 +306,35 @@ async fn test_cluster_recover() {
     let result = handler.recover().await;
     assert!(result.is_ok());
 }
+
+#[tokio::test]
+async fn test_cluster_change_password_hashing_algorithm() {
+    // Closes #57: PATCH /v1/cluster/change_password_hashing_algorithm.
+    // Verified live against Enterprise 8.0.10-81; an empty body returns
+    // 400 empty_request from the cluster.
+    let mock_server = MockServer::start().await;
+
+    Mock::given(method("PATCH"))
+        .and(path("/v1/cluster/change_password_hashing_algorithm"))
+        .and(basic_auth("admin", "password"))
+        .and(wiremock::matchers::body_json(json!({
+            "algorithm": "SHA-512"
+        })))
+        .respond_with(success_response(json!({"algorithm": "SHA-512"})))
+        .mount(&mock_server)
+        .await;
+
+    let client = EnterpriseClient::builder()
+        .base_url(mock_server.uri())
+        .username("admin")
+        .password("password")
+        .build()
+        .unwrap();
+
+    let handler = ClusterHandler::new(client);
+    let result = handler
+        .change_password_hashing_algorithm(json!({"algorithm": "SHA-512"}))
+        .await;
+    assert!(result.is_ok());
+    assert_eq!(result.unwrap()["algorithm"], "SHA-512");
+}

--- a/tests/fixtures/enterprise_unsupported_routes.txt
+++ b/tests/fixtures/enterprise_unsupported_routes.txt
@@ -41,11 +41,6 @@ POST /v2/modules/user-defined
 DELETE /v2/modules/user-defined/{}
 
 # ============================================================================
-# Tracked under #57 — cluster password-hashing algorithm
-# ============================================================================
-PATCH /v1/cluster/change_password_hashing_algorithm
-
-# ============================================================================
 # Per-DB module ops + password rotation — referenced in #65 triage
 # ============================================================================
 POST /v1/bdbs/{}/modules/config


### PR DESCRIPTION
## Summary

Adds the missing `PATCH /v1/cluster/change_password_hashing_algorithm` handler on `ClusterHandler`.

The endpoint is validated against Redis Enterprise Software `8.0.10-81`: an empty body returns `400 empty_request`, confirming the route is served by the live cluster. Body is typed as `serde_json::Value` because the accepted `algorithm` value set is version-dependent and not worth modeling as an enum.

Removes the matching entry from `tests/fixtures/enterprise_unsupported_routes.txt` so the `route_coverage` test sees the endpoint as both documented and handled.

Closes #57.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace` — new wiremock test asserts verb + path + body shape
