### PR TITLE
feat(crdb): add flush, health_report, purge, and updates endpoints

### DIFF
--- a/src/crdb.rs
+++ b/src/crdb.rs
@@ -185,4 +185,49 @@ impl CrdbHandler {
     pub async fn tasks(&self, guid: &str) -> Result<Value> {
         self.client.get(&format!("/v1/crdbs/{}/tasks", guid)).await
     }
+
+    /// Flush all data from an Active-Active database.
+    ///
+    /// `PUT /v1/crdbs/{crdb_guid}/flush`. The request body is intentionally
+    /// `serde_json::Value` because the documented payload is a small set of
+    /// optional flags (e.g. `{}` for the default flush) whose accepted shape
+    /// is version-specific; pass `json!({})` for the common case.
+    pub async fn flush(&self, guid: &str, body: Value) -> Result<Value> {
+        self.client
+            .put_raw(&format!("/v1/crdbs/{}/flush", guid), body)
+            .await
+    }
+
+    /// Retrieve the health report for an Active-Active database.
+    ///
+    /// `GET /v1/crdbs/{crdb_guid}/health_report`. The response is returned
+    /// as `serde_json::Value` because the report is a richly structured
+    /// document whose shape evolves across cluster versions.
+    pub async fn health_report(&self, guid: &str) -> Result<Value> {
+        self.client
+            .get(&format!("/v1/crdbs/{}/health_report", guid))
+            .await
+    }
+
+    /// Purge data from an instance that was forcibly removed from an
+    /// Active-Active database.
+    ///
+    /// `PUT /v1/crdbs/{crdb_guid}/purge`. The body identifies the
+    /// instance(s) to purge; pass a `Value` matching the documented
+    /// shape for the cluster version under test.
+    pub async fn purge(&self, guid: &str, body: Value) -> Result<Value> {
+        self.client
+            .put_raw(&format!("/v1/crdbs/{}/purge", guid), body)
+            .await
+    }
+
+    /// Submit a configuration update against an Active-Active database.
+    ///
+    /// `POST /v1/crdbs/{crdb_guid}/updates`. The body shape is version-
+    /// specific; pass a `Value` with the desired field changes.
+    pub async fn updates(&self, guid: &str, body: Value) -> Result<Value> {
+        self.client
+            .post_raw(&format!("/v1/crdbs/{}/updates", guid), body)
+            .await
+    }
 }

--- a/tests/crdb_tests.rs
+++ b/tests/crdb_tests.rs
@@ -582,3 +582,136 @@ async fn test_crdb_tasks_nonexistent() {
 
     assert!(result.is_err());
 }
+
+// ===========================================================================
+// Closes #54: flush / health_report / purge / updates.
+// Verified against Redis Enterprise Software 8.0.10-81; an invalid GUID
+// returns 400 schema-validation on each route rather than route-level 404.
+// ===========================================================================
+
+#[tokio::test]
+async fn test_crdb_flush() {
+    let mock_server = MockServer::start().await;
+
+    Mock::given(method("PUT"))
+        .and(path("/v1/crdbs/test-guid/flush"))
+        .and(basic_auth("admin", "password"))
+        .and(body_json(json!({})))
+        .respond_with(success_response(json!({"task_id": "flush-123"})))
+        .mount(&mock_server)
+        .await;
+
+    let client = EnterpriseClient::builder()
+        .base_url(mock_server.uri())
+        .username("admin")
+        .password("password")
+        .build()
+        .unwrap();
+
+    let handler = CrdbHandler::new(client);
+    let result = handler.flush("test-guid", json!({})).await.unwrap();
+    assert_eq!(result["task_id"], "flush-123");
+}
+
+#[tokio::test]
+async fn test_crdb_health_report() {
+    let mock_server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/v1/crdbs/test-guid/health_report"))
+        .and(basic_auth("admin", "password"))
+        .respond_with(success_response(
+            json!([{"instance_id": 1, "status": "active"}]),
+        ))
+        .mount(&mock_server)
+        .await;
+
+    let client = EnterpriseClient::builder()
+        .base_url(mock_server.uri())
+        .username("admin")
+        .password("password")
+        .build()
+        .unwrap();
+
+    let handler = CrdbHandler::new(client);
+    let result = handler.health_report("test-guid").await.unwrap();
+    assert_eq!(result[0]["instance_id"], 1);
+    assert_eq!(result[0]["status"], "active");
+}
+
+#[tokio::test]
+async fn test_crdb_purge() {
+    let mock_server = MockServer::start().await;
+
+    Mock::given(method("PUT"))
+        .and(path("/v1/crdbs/test-guid/purge"))
+        .and(basic_auth("admin", "password"))
+        .and(body_json(json!({"instance_id": 2})))
+        .respond_with(success_response(json!({"task_id": "purge-456"})))
+        .mount(&mock_server)
+        .await;
+
+    let client = EnterpriseClient::builder()
+        .base_url(mock_server.uri())
+        .username("admin")
+        .password("password")
+        .build()
+        .unwrap();
+
+    let handler = CrdbHandler::new(client);
+    let result = handler
+        .purge("test-guid", json!({"instance_id": 2}))
+        .await
+        .unwrap();
+    assert_eq!(result["task_id"], "purge-456");
+}
+
+#[tokio::test]
+async fn test_crdb_updates() {
+    let mock_server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .and(path("/v1/crdbs/test-guid/updates"))
+        .and(basic_auth("admin", "password"))
+        .and(body_json(json!({"memory_size": 2_000_000_000_u64})))
+        .respond_with(success_response(json!({"task_id": "update-789"})))
+        .mount(&mock_server)
+        .await;
+
+    let client = EnterpriseClient::builder()
+        .base_url(mock_server.uri())
+        .username("admin")
+        .password("password")
+        .build()
+        .unwrap();
+
+    let handler = CrdbHandler::new(client);
+    let result = handler
+        .updates("test-guid", json!({"memory_size": 2_000_000_000_u64}))
+        .await
+        .unwrap();
+    assert_eq!(result["task_id"], "update-789");
+}
+
+#[tokio::test]
+async fn test_crdb_flush_nonexistent() {
+    let mock_server = MockServer::start().await;
+
+    Mock::given(method("PUT"))
+        .and(path("/v1/crdbs/nonexistent-guid/flush"))
+        .and(basic_auth("admin", "password"))
+        .respond_with(error_response(404, "CRDB not found"))
+        .mount(&mock_server)
+        .await;
+
+    let client = EnterpriseClient::builder()
+        .base_url(mock_server.uri())
+        .username("admin")
+        .password("password")
+        .build()
+        .unwrap();
+
+    let handler = CrdbHandler::new(client);
+    let result = handler.flush("nonexistent-guid", json!({})).await;
+    assert!(result.is_err());
+}

--- a/tests/fixtures/enterprise_unsupported_routes.txt
+++ b/tests/fixtures/enterprise_unsupported_routes.txt
@@ -24,14 +24,6 @@ GET /v1/cluster/sso/saml/metadata/sp
 POST /v1/cluster/sso/saml/metadata/idp
 
 # ============================================================================
-# Tracked under #54 — CRDB write surface
-# ============================================================================
-PUT /v1/crdbs/{}/flush
-PUT /v1/crdbs/{}/purge
-GET /v1/crdbs/{}/health_report
-POST /v1/crdbs/{}/updates
-
-# ============================================================================
 # Tracked under #55 — user-defined modules
 # ============================================================================
 GET /v2/local/modules/user-defined/artifacts


### PR DESCRIPTION
## Summary

Extends `CrdbHandler` with the four documented maintenance endpoints that were previously missing:

| Verb | Path | Method |
|---|---|---|
| `PUT` | `/v1/crdbs/{crdb_guid}/flush` | `flush(guid, body)` |
| `GET` | `/v1/crdbs/{crdb_guid}/health_report` | `health_report(guid)` |
| `PUT` | `/v1/crdbs/{crdb_guid}/purge` | `purge(guid, body)` |
| `POST` | `/v1/crdbs/{crdb_guid}/updates` | `updates(guid, body)` |

All four routes were validated against Redis Enterprise Software `8.0.10-81` on April 21, 2026: an invalid GUID returns a `400` schema-validation response on each route rather than a route-level `404`, confirming the routes are served by the live cluster.

Bodies and responses are typed as `serde_json::Value` because the payload shapes are version-specific (flush/purge accept different option sets across versions; the health report is a richly nested document that evolves across releases). Typed wrappers can be layered on later without breaking these signatures.

Removes the matching entries from `tests/fixtures/enterprise_unsupported_routes.txt` so the `route_coverage` test sees the endpoints as both documented and handled.

Closes #54.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace` — 4 new wiremock happy-path tests + 1 error-path test for `flush`
