### PR TITLE
feat(cluster): add SSO and SAML metadata endpoints

### DIFF
--- a/src/cluster.rs
+++ b/src/cluster.rs
@@ -703,6 +703,54 @@ impl ClusterHandler {
             .get(&format!("/v1/cluster/alerts/{}", alert))
             .await
     }
+
+    /// Get the current cluster single-sign-on (SSO) configuration.
+    ///
+    /// `GET /v1/cluster/sso`. Returned as `serde_json::Value` because the
+    /// SSO config schema is version-specific and includes optional SAML,
+    /// OIDC, and certificate fields.
+    pub async fn sso(&self) -> Result<Value> {
+        self.client.get("/v1/cluster/sso").await
+    }
+
+    /// Set or update the cluster SSO configuration.
+    ///
+    /// `PUT /v1/cluster/sso`. Pass a `Value` matching the documented
+    /// SSO config shape for the cluster version under test.
+    pub async fn update_sso(&self, body: Value) -> Result<Value> {
+        self.client.put_raw("/v1/cluster/sso", body).await
+    }
+
+    /// Clear the cluster SSO configuration.
+    ///
+    /// `DELETE /v1/cluster/sso`.
+    pub async fn delete_sso(&self) -> Result<()> {
+        self.client.delete("/v1/cluster/sso").await
+    }
+
+    /// Fetch the SAML service-provider metadata for the cluster.
+    ///
+    /// `GET /v1/cluster/sso/saml/metadata/sp`. The cluster returns the SP
+    /// metadata document so callers can register it with their identity
+    /// provider. Returned as `Value` because the wire format varies by
+    /// cluster version. Live verification on 8.0.10-81 produced
+    /// `406 missing_certificate` until a SAML signing certificate is
+    /// provisioned on the cluster.
+    pub async fn sso_saml_metadata_sp(&self) -> Result<Value> {
+        self.client.get("/v1/cluster/sso/saml/metadata/sp").await
+    }
+
+    /// Upload SAML identity-provider metadata to the cluster.
+    ///
+    /// `POST /v1/cluster/sso/saml/metadata/idp`. The body shape is
+    /// version-specific (typically a wrapper around the IdP metadata
+    /// document); pass a `Value` matching the documented payload for the
+    /// cluster version under test.
+    pub async fn sso_saml_metadata_idp(&self, body: Value) -> Result<Value> {
+        self.client
+            .post_raw("/v1/cluster/sso/saml/metadata/idp", body)
+            .await
+    }
 }
 
 /// Node information

--- a/tests/cluster_tests.rs
+++ b/tests/cluster_tests.rs
@@ -338,3 +338,148 @@ async fn test_cluster_change_password_hashing_algorithm() {
     assert!(result.is_ok());
     assert_eq!(result.unwrap()["algorithm"], "SHA-512");
 }
+
+// ===========================================================================
+// Closes #56: cluster SSO endpoints.
+// Verified against Redis Enterprise Software 8.0.10-81; GET /v1/cluster/sso
+// returns 200, GET .../saml/metadata/sp returns 406 missing_certificate
+// (cert not yet provisioned), POST .../saml/metadata/idp returns
+// 400 empty_request on an empty body. All confirm live routing.
+// ===========================================================================
+
+#[tokio::test]
+async fn test_cluster_sso_get() {
+    let mock_server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/v1/cluster/sso"))
+        .and(basic_auth("admin", "password"))
+        .respond_with(success_response(json!({
+            "saml": {"enabled": true, "issuer": "https://idp.example.com"}
+        })))
+        .mount(&mock_server)
+        .await;
+
+    let client = EnterpriseClient::builder()
+        .base_url(mock_server.uri())
+        .username("admin")
+        .password("password")
+        .build()
+        .unwrap();
+
+    let handler = ClusterHandler::new(client);
+    let result = handler.sso().await.unwrap();
+    assert_eq!(result["saml"]["enabled"], true);
+}
+
+#[tokio::test]
+async fn test_cluster_sso_update() {
+    let mock_server = MockServer::start().await;
+
+    Mock::given(method("PUT"))
+        .and(path("/v1/cluster/sso"))
+        .and(basic_auth("admin", "password"))
+        .and(wiremock::matchers::body_json(json!({
+            "saml": {"enabled": true}
+        })))
+        .respond_with(success_response(json!({"saml": {"enabled": true}})))
+        .mount(&mock_server)
+        .await;
+
+    let client = EnterpriseClient::builder()
+        .base_url(mock_server.uri())
+        .username("admin")
+        .password("password")
+        .build()
+        .unwrap();
+
+    let handler = ClusterHandler::new(client);
+    let result = handler
+        .update_sso(json!({"saml": {"enabled": true}}))
+        .await
+        .unwrap();
+    assert_eq!(result["saml"]["enabled"], true);
+}
+
+#[tokio::test]
+async fn test_cluster_sso_delete() {
+    let mock_server = MockServer::start().await;
+
+    Mock::given(method("DELETE"))
+        .and(path("/v1/cluster/sso"))
+        .and(basic_auth("admin", "password"))
+        .respond_with(ResponseTemplate::new(200))
+        .mount(&mock_server)
+        .await;
+
+    let client = EnterpriseClient::builder()
+        .base_url(mock_server.uri())
+        .username("admin")
+        .password("password")
+        .build()
+        .unwrap();
+
+    let handler = ClusterHandler::new(client);
+    assert!(handler.delete_sso().await.is_ok());
+}
+
+#[tokio::test]
+async fn test_cluster_sso_saml_metadata_sp() {
+    let mock_server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/v1/cluster/sso/saml/metadata/sp"))
+        .and(basic_auth("admin", "password"))
+        .respond_with(success_response(json!({
+            "metadata": "<EntityDescriptor entityID=\"https://example\" />"
+        })))
+        .mount(&mock_server)
+        .await;
+
+    let client = EnterpriseClient::builder()
+        .base_url(mock_server.uri())
+        .username("admin")
+        .password("password")
+        .build()
+        .unwrap();
+
+    let handler = ClusterHandler::new(client);
+    let result = handler.sso_saml_metadata_sp().await.unwrap();
+    assert!(
+        result["metadata"]
+            .as_str()
+            .unwrap()
+            .contains("EntityDescriptor")
+    );
+}
+
+#[tokio::test]
+async fn test_cluster_sso_saml_metadata_idp() {
+    let mock_server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .and(path("/v1/cluster/sso/saml/metadata/idp"))
+        .and(basic_auth("admin", "password"))
+        .and(wiremock::matchers::body_json(json!({
+            "metadata": "<EntityDescriptor entityID=\"idp\" />"
+        })))
+        .respond_with(success_response(json!({"status": "accepted"})))
+        .mount(&mock_server)
+        .await;
+
+    let client = EnterpriseClient::builder()
+        .base_url(mock_server.uri())
+        .username("admin")
+        .password("password")
+        .build()
+        .unwrap();
+
+    let handler = ClusterHandler::new(client);
+    let result = handler
+        .sso_saml_metadata_idp(json!({
+            "metadata": "<EntityDescriptor entityID=\"idp\" />"
+        }))
+        .await
+        .unwrap();
+    assert_eq!(result["status"], "accepted");
+}

--- a/tests/fixtures/enterprise_unsupported_routes.txt
+++ b/tests/fixtures/enterprise_unsupported_routes.txt
@@ -15,15 +15,6 @@
 # implemented without updating the allowlist).
 
 # ============================================================================
-# Tracked under #56 — cluster SSO/SAML endpoints
-# ============================================================================
-GET /v1/cluster/sso
-PUT /v1/cluster/sso
-DELETE /v1/cluster/sso
-GET /v1/cluster/sso/saml/metadata/sp
-POST /v1/cluster/sso/saml/metadata/idp
-
-# ============================================================================
 # Tracked under #55 — user-defined modules
 # ============================================================================
 GET /v2/local/modules/user-defined/artifacts


### PR DESCRIPTION
## Summary

Extends `ClusterHandler` with the five documented cluster SSO endpoints that were previously missing:

| Verb | Path | Method |
|---|---|---|
| `GET` | `/v1/cluster/sso` | `sso()` |
| `PUT` | `/v1/cluster/sso` | `update_sso(body)` |
| `DELETE` | `/v1/cluster/sso` | `delete_sso()` |
| `GET` | `/v1/cluster/sso/saml/metadata/sp` | `sso_saml_metadata_sp()` |
| `POST` | `/v1/cluster/sso/saml/metadata/idp` | `sso_saml_metadata_idp(body)` |

Validated against Redis Enterprise Software `8.0.10-81` on April 21, 2026: `GET /v1/cluster/sso` returns `200`, the SP-metadata route returns `406 missing_certificate` (cluster lacks a SAML signing cert in the test environment), and the IDP-metadata route returns `400 empty_request` on an empty body. All three confirm the routes are served by the live cluster.

Bodies and responses are typed as `serde_json::Value` because the SSO config and SAML metadata payloads are version-specific (include optional SAML, OIDC, and certificate fields). Typed wrappers can be layered on later without breaking these signatures.

Removes the matching entries from `tests/fixtures/enterprise_unsupported_routes.txt` so the `route_coverage` test sees the endpoints as both documented and handled.

Closes #56.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace` — 5 new wiremock tests, one per endpoint
