### PR TITLE
feat(modules): add user-defined module management endpoints

### DIFF
--- a/src/modules.rs
+++ b/src/modules.rs
@@ -169,4 +169,77 @@ impl ModuleHandler {
             .post(&format!("/v1/modules/config/bdb/{}", bdb_uid), &config)
             .await
     }
+
+    /// List custom module artifacts on the local node.
+    ///
+    /// `GET /v2/local/modules/user-defined/artifacts`. Live verification on
+    /// Redis Enterprise Software 8.0.10-81 returned `200 OK` with `[]` on a
+    /// cluster with no custom modules uploaded.
+    pub async fn list_user_defined_artifacts(&self) -> Result<Value> {
+        self.client
+            .get("/v2/local/modules/user-defined/artifacts")
+            .await
+    }
+
+    /// Upload a custom module artifact to the local node.
+    ///
+    /// `POST /v2/local/modules/user-defined/artifacts`. The endpoint expects
+    /// a multipart upload; the file is sent under the `module` form field
+    /// to match the existing v1/v2 module upload behaviour. Live
+    /// verification on 8.0.10-81 returned `400 no_module` when an empty
+    /// body was sent.
+    pub async fn upload_user_defined_artifact(
+        &self,
+        module_data: Vec<u8>,
+        file_name: &str,
+    ) -> Result<Value> {
+        self.client
+            .post_multipart(
+                "/v2/local/modules/user-defined/artifacts",
+                module_data,
+                "module",
+                file_name,
+            )
+            .await
+    }
+
+    /// Register a previously-uploaded artifact as a cluster-wide
+    /// user-defined module configuration.
+    ///
+    /// `POST /v2/modules/user-defined`. The body shape is version-specific
+    /// (it must reference an artifact that has already been uploaded via
+    /// [`upload_user_defined_artifact`](Self::upload_user_defined_artifact)
+    /// and describe how the cluster should load it); pass a `Value`
+    /// matching the documented payload. Live verification on 8.0.10-81
+    /// returned `406 invalid_module` when an empty body was sent.
+    pub async fn register_user_defined(&self, body: Value) -> Result<Value> {
+        self.client.post_raw("/v2/modules/user-defined", body).await
+    }
+
+    /// Delete a custom module configuration cluster-wide.
+    ///
+    /// `DELETE /v2/modules/user-defined/{uid}`. Live verification on
+    /// 8.0.10-81 returned `404 module_delete_failed` against a uid that
+    /// does not exist on the cluster.
+    pub async fn delete_user_defined(&self, uid: &str) -> Result<()> {
+        self.client
+            .delete(&format!("/v2/modules/user-defined/{}", uid))
+            .await
+    }
+
+    /// Delete a custom module artifact from the local node.
+    ///
+    /// `DELETE /v2/local/modules/user-defined/artifacts/{module_name}/{version}`.
+    pub async fn delete_user_defined_artifact(
+        &self,
+        module_name: &str,
+        version: &str,
+    ) -> Result<()> {
+        self.client
+            .delete(&format!(
+                "/v2/local/modules/user-defined/artifacts/{}/{}",
+                module_name, version
+            ))
+            .await
+    }
 }

--- a/tests/fixtures/enterprise_unsupported_routes.txt
+++ b/tests/fixtures/enterprise_unsupported_routes.txt
@@ -15,15 +15,6 @@
 # implemented without updating the allowlist).
 
 # ============================================================================
-# Tracked under #55 — user-defined modules
-# ============================================================================
-GET /v2/local/modules/user-defined/artifacts
-POST /v2/local/modules/user-defined/artifacts
-DELETE /v2/local/modules/user-defined/artifacts/{}/{}
-POST /v2/modules/user-defined
-DELETE /v2/modules/user-defined/{}
-
-# ============================================================================
 # Per-DB module ops + password rotation — referenced in #65 triage
 # ============================================================================
 POST /v1/bdbs/{}/modules/config

--- a/tests/module_tests.rs
+++ b/tests/module_tests.rs
@@ -261,3 +261,149 @@ async fn test_module_get_with_platforms_map() {
         "Platforms field should be present"
     );
 }
+
+// ===========================================================================
+// Closes #55: user-defined module endpoints.
+// Verified against Redis Enterprise Software 8.0.10-81 on 2026-04-21:
+// - GET  /v2/local/modules/user-defined/artifacts -> 200 OK with []
+// - POST /v2/modules/user-defined with {}         -> 406 invalid_module
+// - POST /v2/local/modules/user-defined/artifacts -> 400 no_module
+// - DELETE /v2/modules/user-defined/1             -> 404 module_delete_failed
+// All four confirm the routes are served by the live cluster.
+// ===========================================================================
+
+#[tokio::test]
+async fn test_module_list_user_defined_artifacts() {
+    let mock_server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/v2/local/modules/user-defined/artifacts"))
+        .and(basic_auth("admin", "password"))
+        .respond_with(success_response(
+            json!([{"module_name": "myext", "version": "1.0.0"}]),
+        ))
+        .mount(&mock_server)
+        .await;
+
+    let client = EnterpriseClient::builder()
+        .base_url(mock_server.uri())
+        .username("admin")
+        .password("password")
+        .build()
+        .unwrap();
+
+    let handler = ModuleHandler::new(client);
+    let result = handler.list_user_defined_artifacts().await.unwrap();
+    assert_eq!(result[0]["module_name"], "myext");
+    assert_eq!(result[0]["version"], "1.0.0");
+}
+
+#[tokio::test]
+async fn test_module_upload_user_defined_artifact() {
+    let mock_server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .and(path("/v2/local/modules/user-defined/artifacts"))
+        .and(basic_auth("admin", "password"))
+        .respond_with(success_response(
+            json!({"module_name": "myext", "version": "1.0.0"}),
+        ))
+        .mount(&mock_server)
+        .await;
+
+    let client = EnterpriseClient::builder()
+        .base_url(mock_server.uri())
+        .username("admin")
+        .password("password")
+        .build()
+        .unwrap();
+
+    let handler = ModuleHandler::new(client);
+    let result = handler
+        .upload_user_defined_artifact(vec![1, 2, 3, 4], "myext-1.0.0.zip")
+        .await
+        .unwrap();
+    assert_eq!(result["module_name"], "myext");
+}
+
+#[tokio::test]
+async fn test_module_register_user_defined() {
+    let mock_server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .and(path("/v2/modules/user-defined"))
+        .and(basic_auth("admin", "password"))
+        .and(wiremock::matchers::body_json(json!({
+            "module_name": "myext",
+            "version": "1.0.0"
+        })))
+        .respond_with(success_response(json!({"uid": "42"})))
+        .mount(&mock_server)
+        .await;
+
+    let client = EnterpriseClient::builder()
+        .base_url(mock_server.uri())
+        .username("admin")
+        .password("password")
+        .build()
+        .unwrap();
+
+    let handler = ModuleHandler::new(client);
+    let result = handler
+        .register_user_defined(json!({
+            "module_name": "myext",
+            "version": "1.0.0"
+        }))
+        .await
+        .unwrap();
+    assert_eq!(result["uid"], "42");
+}
+
+#[tokio::test]
+async fn test_module_delete_user_defined() {
+    let mock_server = MockServer::start().await;
+
+    Mock::given(method("DELETE"))
+        .and(path("/v2/modules/user-defined/42"))
+        .and(basic_auth("admin", "password"))
+        .respond_with(ResponseTemplate::new(200))
+        .mount(&mock_server)
+        .await;
+
+    let client = EnterpriseClient::builder()
+        .base_url(mock_server.uri())
+        .username("admin")
+        .password("password")
+        .build()
+        .unwrap();
+
+    let handler = ModuleHandler::new(client);
+    assert!(handler.delete_user_defined("42").await.is_ok());
+}
+
+#[tokio::test]
+async fn test_module_delete_user_defined_artifact() {
+    let mock_server = MockServer::start().await;
+
+    Mock::given(method("DELETE"))
+        .and(path("/v2/local/modules/user-defined/artifacts/myext/1.0.0"))
+        .and(basic_auth("admin", "password"))
+        .respond_with(ResponseTemplate::new(200))
+        .mount(&mock_server)
+        .await;
+
+    let client = EnterpriseClient::builder()
+        .base_url(mock_server.uri())
+        .username("admin")
+        .password("password")
+        .build()
+        .unwrap();
+
+    let handler = ModuleHandler::new(client);
+    assert!(
+        handler
+            .delete_user_defined_artifact("myext", "1.0.0")
+            .await
+            .is_ok()
+    );
+}


### PR DESCRIPTION
## Summary

Extends `ModuleHandler` with the five documented user-defined module endpoints that were previously missing:

| Verb | Path | Method |
|---|---|---|
| `GET` | `/v2/local/modules/user-defined/artifacts` | `list_user_defined_artifacts()` |
| `POST` | `/v2/local/modules/user-defined/artifacts` | `upload_user_defined_artifact(module_data, file_name)` |
| `POST` | `/v2/modules/user-defined` | `register_user_defined(body)` |
| `DELETE` | `/v2/modules/user-defined/{uid}` | `delete_user_defined(uid)` |
| `DELETE` | `/v2/local/modules/user-defined/artifacts/{module_name}/{version}` | `delete_user_defined_artifact(module_name, version)` |

Validated against Redis Enterprise Software `8.0.10-81` on April 21, 2026:

- `GET /v2/local/modules/user-defined/artifacts` → `200 OK` with `[]`
- `POST /v2/modules/user-defined` with `{}` → `406 invalid_module`
- `POST /v2/local/modules/user-defined/artifacts` with `{}` → `400 no_module`
- `DELETE /v2/modules/user-defined/1` → `404 module_delete_failed`

All four confirm the routes are served by the live cluster.

The artifact-upload endpoint uses `post_multipart` with the `module` form field, matching the existing v1/v2 module upload behaviour. Registration / listing bodies and responses are typed as `serde_json::Value` because the payloads carry version-specific metadata (module configuration, dependencies, signing info); typed wrappers can be layered on later without breaking these signatures.

Removes the matching entries from `tests/fixtures/enterprise_unsupported_routes.txt` so the `route_coverage` test sees the endpoints as both documented and handled.

Closes #55.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace` — 5 new wiremock tests, one per endpoint
