### PR TITLE
refactor(bdb): remove fictional actions/{backup,restore,upgrade}

### DIFF
--- a/src/bdb.rs
+++ b/src/bdb.rs
@@ -33,10 +33,6 @@
 //! # async fn example(client: EnterpriseClient) -> Result<(), Box<dyn std::error::Error>> {
 //! let db_id = 1;
 //!
-//! // Backup database
-//! let backup = client.databases().backup(db_id).await?;
-//! println!("Backup started: {:?}", backup.action_uid);
-//!
 //! // Export to remote location
 //! let export = client.databases().export(db_id, "ftp://backup.site/db.rdb").await?;
 //! println!("Export initiated: {:?}", export.action_uid);
@@ -93,16 +89,6 @@ pub struct DatabaseActionResponse {
     pub action_uid: String,
     /// Description of the action
     pub description: Option<String>,
-}
-
-/// Response from backup operation
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct BackupResponse {
-    /// The action UID for tracking the backup operation
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub action_uid: Option<String>,
-    /// Backup UID if available
-    pub backup_uid: Option<String>,
 }
 
 /// Response from import operation
@@ -793,32 +779,6 @@ impl DatabaseHandler {
         serde_json::from_value(response).map_err(Into::into)
     }
 
-    /// Backup database (BDB.BACKUP)
-    pub async fn backup(&self, uid: u32) -> Result<BackupResponse> {
-        self.client
-            .post(
-                &format!("/v1/bdbs/{}/actions/backup", uid),
-                &serde_json::json!({}),
-            )
-            .await
-    }
-
-    /// Restore database from backup (BDB.RESTORE)
-    pub async fn restore(
-        &self,
-        uid: u32,
-        backup_uid: Option<&str>,
-    ) -> Result<DatabaseActionResponse> {
-        let body = if let Some(backup_id) = backup_uid {
-            serde_json::json!({ "backup_uid": backup_id })
-        } else {
-            serde_json::json!({})
-        };
-        self.client
-            .post(&format!("/v1/bdbs/{}/actions/restore", uid), &body)
-            .await
-    }
-
     /// Get database shards (BDB.SHARDS)
     pub async fn shards(&self, uid: u32) -> Result<Value> {
         self.client.get(&format!("/v1/bdbs/{}/shards", uid)).await
@@ -1072,22 +1032,6 @@ impl DatabaseHandler {
                 "/v1/bdbs/replica_sources/alerts/{}/{}/{}",
                 uid, source_id, alert
             ))
-            .await
-    }
-
-    /// Upgrade database with new module version (BDB.UPGRADE)
-    pub async fn upgrade(
-        &self,
-        uid: u32,
-        module_name: &str,
-        new_version: &str,
-    ) -> Result<DatabaseActionResponse> {
-        let body = serde_json::json!({
-            "module_name": module_name,
-            "new_version": new_version
-        });
-        self.client
-            .post(&format!("/v1/bdbs/{}/actions/upgrade", uid), &body)
             .await
     }
 

--- a/src/lib_tests.rs
+++ b/src/lib_tests.rs
@@ -314,34 +314,6 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_database_action_backup() {
-        let mock_server = MockServer::start().await;
-
-        Mock::given(method("POST"))
-            .and(path("/v1/bdbs/1/actions/backup"))
-            .and(basic_auth("admin", "password"))
-            .respond_with(
-                ResponseTemplate::new(200)
-                    .set_body_json(serde_json::json!({"backup_uid": "backup-789"})),
-            )
-            .mount(&mock_server)
-            .await;
-
-        let client = EnterpriseClient::builder()
-            .base_url(mock_server.uri())
-            .username("admin")
-            .password("password")
-            .build()
-            .unwrap();
-
-        let handler = crate::bdb::DatabaseHandler::new(client);
-        let result = handler.backup(1).await;
-
-        assert!(result.is_ok());
-        assert!(result.unwrap().backup_uid.is_some());
-    }
-
-    #[tokio::test]
     async fn test_database_get_shards() {
         let mock_server = MockServer::start().await;
 

--- a/tests/bdb/actions.rs
+++ b/tests/bdb/actions.rs
@@ -43,58 +43,6 @@ async fn test_database_import() {
 }
 
 #[tokio::test]
-async fn test_database_backup() {
-    let mock_server = MockServer::start().await;
-
-    Mock::given(method("POST"))
-        .and(path("/v1/bdbs/1/actions/backup"))
-        .and(basic_auth("admin", "password"))
-        .respond_with(success_response(json!({"backup_id": "backup-789"})))
-        .mount(&mock_server)
-        .await;
-
-    let client = test_client(&mock_server);
-    let result = client.databases().backup(1).await;
-    assert!(result.is_ok());
-}
-
-#[tokio::test]
-async fn test_database_restore() {
-    let mock_server = MockServer::start().await;
-
-    Mock::given(method("POST"))
-        .and(path("/v1/bdbs/1/actions/restore"))
-        .and(basic_auth("admin", "password"))
-        .respond_with(success_response(
-            json!({"action_uid": "act-restore-1", "status": "restored"}),
-        ))
-        .mount(&mock_server)
-        .await;
-
-    let client = test_client(&mock_server);
-    let result = client.databases().restore(1, Some("backup-789")).await;
-    assert!(result.is_ok());
-}
-
-#[tokio::test]
-async fn test_database_upgrade_module() {
-    let mock_server = MockServer::start().await;
-
-    Mock::given(method("POST"))
-        .and(path("/v1/bdbs/1/actions/upgrade"))
-        .and(basic_auth("admin", "password"))
-        .respond_with(success_response(
-            json!({"action_uid": "act-up-1", "status": "upgraded"}),
-        ))
-        .mount(&mock_server)
-        .await;
-
-    let client = test_client(&mock_server);
-    let result = client.databases().upgrade(1, "search", "2.0").await;
-    assert!(result.is_ok());
-}
-
-#[tokio::test]
 async fn test_database_optimize_shards_placement_status() {
     let mock_server = MockServer::start().await;
 

--- a/tests/fixtures/enterprise_non_spec_routes.txt
+++ b/tests/fixtures/enterprise_non_spec_routes.txt
@@ -46,9 +46,6 @@ PUT /v1/bdb_groups/{}
 # ============================================================================
 # bdbs subresources — many real endpoints not in the inventory
 # (stats, endpoints, proxies, alert_settings, flush, reset_admin_pass).
-# `actions/backup` and `actions/restore` are not in the docs — flagged
-# under #65 for triage; comment in src/bdb.rs acknowledges they may be
-# fictional.
 # ============================================================================
 GET /v1/bdbs/metrics/{}
 GET /v1/bdbs/{}/alert_settings
@@ -57,9 +54,6 @@ GET /v1/bdbs/{}/endpoints
 GET /v1/bdbs/{}/proxies
 GET /v1/bdbs/{}/stats
 GET /v1/bdbs/{}/stats/last
-POST /v1/bdbs/{}/actions/backup
-POST /v1/bdbs/{}/actions/restore
-POST /v1/bdbs/{}/actions/upgrade
 PUT /v1/bdbs/{}/alert_settings
 PUT /v1/bdbs/{}/flush
 PUT /v1/bdbs/{}/reset_admin_pass


### PR DESCRIPTION
## Summary

Deletes three `DatabaseHandler` methods that hit routes which **do not exist in the Redis Enterprise REST API docs at any version**:

| Method | Route | Verdict |
|---|---|---|
| `backup(uid)` | `POST /v1/bdbs/{uid}/actions/backup` | Fictional — not in `requests/bdbs/actions/` enumeration |
| `restore(uid, backup_uid)` | `POST /v1/bdbs/{uid}/actions/restore` | Fictional — same |
| `upgrade(uid, module, version)` | `POST /v1/bdbs/{uid}/actions/upgrade` | Superseded by `upgrade_redis_version` at the documented `/v1/bdbs/{uid}/upgrade` |

Per the audit in #65 ([`docs/api-gap-triage.md`](https://github.com/redis-developer/redis-enterprise-rs/blob/audit/non-spec-routes-triage/docs/api-gap-triage.md)):

- The documented `bdbs/actions/` page is an explicit, complete enumeration of action endpoints (11 entries). `backup` and `restore` aren't on the list. Real backup/restore flows go through scheduled-backup configuration on the bdb object plus `actions/recover`, `actions/export`, and `actions/import`, which this handler already exposes.
- `actions/upgrade` is superseded by `upgrade_redis_version` on line 1133 of the same file, which POSTs to the documented path `/v1/bdbs/{uid}/upgrade` (no `actions/` prefix).

Also removes the now-dead `BackupResponse` struct (the deleted `backup` method was its only caller).

## Caller adaptations

| File | Change |
|---|---|
| `src/bdb.rs` | Doc example dropped the backup-database snippet; surrounding example covers export/import. |
| `src/lib_tests.rs` | Removed `test_database_action_backup`. |
| `tests/bdb/actions.rs` | Removed `test_database_backup`, `test_database_restore`, `test_database_upgrade_module`. The documented Redis-version upgrade is exercised by `test_database_upgrade_redis_version` elsewhere. |
| `tests/fixtures/enterprise_non_spec_routes.txt` | Removed the three matching allowlist entries and reworded the bdbs-subresources comment block to drop the now-stale "actions/backup ... may be fictional" note. |

## Scope

Refs #65 — second of several follow-up PRs. Triage `Remove` bucket for the **bdb module**: 3 of 32 entries cleared. Next PR will tackle `services.rs` / `jsonschema.rs` / `usage_report.rs`.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace` — all suites pass; no test references the deleted methods.
