### PR TITLE
docs: README + examples refresh for v0.9.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,10 +28,10 @@ A comprehensive Rust client library for the Redis Enterprise REST API, with Pyth
 
 ```toml
 [dependencies]
-redis-enterprise = "0.8.7"
+redis-enterprise = "0.9"
 
 # Optional: Enable Tower service integration
-redis-enterprise = { version = "0.8.7", features = ["tower-integration"] }
+redis-enterprise = { version = "0.9", features = ["tower-integration"] }
 ```
 
 ## Quick Start
@@ -41,29 +41,39 @@ use redis_enterprise::EnterpriseClient;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    // Create client using builder pattern
-    let client = EnterpriseClient::builder()
-        .base_url("https://cluster.example.com:9443")
-        .username("admin@example.com")
-        .password("your-password")
-        .insecure(false) // Set to true for self-signed certificates
-        .build()?;
+    // Build from environment variables (REDIS_ENTERPRISE_URL/USER/PASSWORD/INSECURE)
+    let client = EnterpriseClient::from_env()?;
+
+    // Or build explicitly:
+    // let client = EnterpriseClient::builder()
+    //     .base_url("https://cluster.example.com:9443")
+    //     .username("admin@example.com")
+    //     .password("your-password")
+    //     .insecure(false) // Set to true for self-signed certificates
+    //     .build()?;
 
     // Get cluster information
     let cluster = client.cluster().info().await?;
-    println!("Cluster: {:?}", cluster);
+    println!("Cluster: {}", cluster.name);
 
     // List databases (BDBs)
     let databases = client.databases().list().await?;
-    println!("Databases: {:?}", databases);
+    for db in &databases {
+        println!("  {} (uid {})", db.name, db.uid);
+    }
 
-    // Get node statistics
+    // List nodes
     let nodes = client.nodes().list().await?;
-    println!("Nodes: {:?}", nodes);
+    for node in &nodes {
+        println!("  Node {}: {} ({})", node.uid, node.addr.as_deref().unwrap_or("?"), node.status);
+    }
 
     Ok(())
 }
 ```
+
+See the [`examples/`](examples) directory for end-to-end workflows: `basic_enterprise`,
+`cluster_setup_simple`, `crdb_basics`, and `database_actions`.
 
 ## Tower Integration
 
@@ -98,84 +108,46 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
 This enables composition with Tower middleware like circuit breakers, retry, rate limiting, and more.
 
+## Environment Variables
+
+- `REDIS_ENTERPRISE_URL` — Base URL (default: `https://localhost:9443`)
+- `REDIS_ENTERPRISE_USER` — Username
+- `REDIS_ENTERPRISE_PASSWORD` — Password
+- `REDIS_ENTERPRISE_INSECURE` — Set to `true` to skip TLS verification (dev only)
+- `REDIS_ENTERPRISE_CA_CERT` — Path to a custom CA certificate PEM file
+
 ## Python Bindings
 
-This library also provides Python bindings via PyO3:
+A thin PyO3 binding covering a subset of read operations is published at
+[redis-enterprise on PyPI](https://pypi.org/project/redis-enterprise/).
+See [`python/README.md`](python/README.md) for the supported API.
 
-```bash
-pip install redis-enterprise
-```
-
-```python
-from redis_enterprise import EnterpriseClient
-
-# Create client
-client = EnterpriseClient(
-    base_url="https://cluster:9443",
-    username="admin@redis.local",
-    password="secret",
-    insecure=True  # For self-signed certs
-)
-
-# Or from environment variables
-client = EnterpriseClient.from_env()
-
-# Async usage
-async def main():
-    dbs = await client.databases()
-    for db in dbs:
-        print(db["name"], db["uid"])
-
-# Sync usage
-dbs = client.databases_sync()
-```
-
-### Python API
-
-- `EnterpriseClient(base_url, username, password, insecure=False, timeout_secs=None)`
-- `EnterpriseClient.from_env()` - Create from environment variables
-
-#### Cluster
-- `cluster_info()` / `cluster_info_sync()` - Get cluster info
-- `cluster_stats()` / `cluster_stats_sync()` - Get cluster statistics
-- `license()` / `license_sync()` - Get license info
-
-#### Databases
-- `databases()` / `databases_sync()` - List all databases
-- `database(uid)` / `database_sync(uid)` - Get database by UID
-
-#### Nodes
-- `nodes()` / `nodes_sync()` - List all nodes
-- `node(uid)` / `node_sync(uid)` - Get node by UID
-
-#### Users
-- `users()` / `users_sync()` - List all users
-
-#### Raw API
-- `get(path)` / `get_sync(path)` - Raw GET request
-- `post(path, body)` / `post_sync(path, body)` - Raw POST request
-- `delete(path)` / `delete_sync(path)` - Raw DELETE request
-
-### Environment Variables
-
-- `REDIS_ENTERPRISE_URL` - Base URL (default: https://localhost:9443)
-- `REDIS_ENTERPRISE_USER` - Username
-- `REDIS_ENTERPRISE_PASSWORD` - Password
-- `REDIS_ENTERPRISE_INSECURE` - Set to "true" for self-signed certs
-- `REDIS_ENTERPRISE_CA_CERT` - Path to a custom CA certificate PEM file
+The PyPI publish workflow has been failing since the `reqwest 0.13` upgrade
+([#25](https://github.com/redis-developer/redis-enterprise-rs/issues/25)) and the
+overall scope is still being scoped under
+[#51](https://github.com/redis-developer/redis-enterprise-rs/issues/51) — treat
+the Python surface as experimental for now.
 
 ## API Coverage
 
-This library provides 100% coverage of the Redis Enterprise REST API, including:
+The crate aims for comprehensive coverage of the documented Redis Enterprise
+REST API surface. Handler organization:
 
-- **Cluster Operations** - Bootstrap, configuration, topology
-- **Database Management** - CRUD operations, actions, statistics
-- **Node Management** - Add/remove nodes, statistics, actions
-- **Security** - Users, roles, ACLs, LDAP integration
-- **Modules** - Upload and manage Redis modules
-- **Monitoring** - Stats, alerts, logs, diagnostics
-- **Active-Active** - CRDB management and tasks
-- **Administration** - License, certificates, services
+- **Cluster** — bootstrap, info, topology, SSO/SAML, settings, license
+- **Databases (BDB)** — CRUD, actions (recover/export/import/flush/upgrade),
+  per-DB alerts, endpoints, stats
+- **Nodes** — list, get, stats, actions, snapshots, check
+- **Security** — users, roles, RBAC, LDAP mappings, redis_acls
+- **Modules** — v1 + v2 module management, user-defined module artifacts
+- **Active-Active (CRDB)** — list / create / update / delete / tasks plus
+  flush, health_report, purge, updates
+- **Monitoring** — stats, alerts, logs, diagnostics, job_scheduler
+- **Administration** — license, certificates, OCSP, debug info, services
+
+For an authoritative per-endpoint inventory see
+[`docs/api-inventory.csv`](docs/api-inventory.csv). For the historical audit
+of routes the SDK once exposed but the docs do not, see
+[`docs/api-gap-triage.md`](docs/api-gap-triage.md).
 
 ## Documentation
 

--- a/examples/cluster_setup_simple.rs
+++ b/examples/cluster_setup_simple.rs
@@ -1,138 +1,96 @@
-//! Simple cluster setup example
+//! Simple cluster + database setup using the typed fluent API.
 //!
-//! This example demonstrates the basic workflow for setting up a Redis Enterprise cluster.
+//! Creates a small disposable database, polls until it goes active, prints a
+//! few facts about it, then cleans up. Intended to be run against a local
+//! Redis Enterprise cluster brought up via the
+//! [live-validation runbook](../docs/live-validation.md).
 //!
 //! Run with:
 //! ```bash
+//! REDIS_ENTERPRISE_URL=https://localhost:9443 \
+//! REDIS_ENTERPRISE_USER=admin@redis.local \
+//! REDIS_ENTERPRISE_PASSWORD=Redis123! \
+//! REDIS_ENTERPRISE_INSECURE=true \
 //! cargo run --example cluster_setup_simple
 //! ```
 
-use redis_enterprise::{EnterpriseClient, bdb::DatabaseHandler};
-use serde_json::json;
+use redis_enterprise::{CreateDatabaseRequest, EnterpriseClient};
 use std::env;
+use std::time::Duration;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    env_logger::init();
+    let client = EnterpriseClient::from_env()?;
 
-    // Configuration from environment or defaults
-    let base_url =
-        env::var("REDIS_ENTERPRISE_URL").unwrap_or_else(|_| "https://localhost:9443".to_string());
-    let username =
-        env::var("REDIS_ENTERPRISE_USER").unwrap_or_else(|_| "admin@redis.local".to_string());
-    let password =
-        env::var("REDIS_ENTERPRISE_PASSWORD").unwrap_or_else(|_| "Redis123!".to_string());
-    let insecure = env::var("REDIS_ENTERPRISE_INSECURE")
-        .unwrap_or_else(|_| "true".to_string())
-        .parse::<bool>()
-        .unwrap_or(true);
+    println!("Redis Enterprise — disposable database walkthrough");
+    println!("===================================================\n");
 
-    println!("Redis Enterprise Cluster Setup");
-    println!("==============================");
-    println!("URL: {}", base_url);
-    println!("Username: {}", username);
+    // Step 1: Cluster status via the typed handler.
+    println!("Step 1: cluster status");
+    match client.cluster().info().await {
+        Ok(cluster) => println!("  ✓ cluster initialized: {}\n", cluster.name),
+        Err(e) => {
+            eprintln!("  ⚠ cluster info failed: {e}");
+            eprintln!("  → the cluster may need bootstrap; see docs/live-validation.md\n");
+            return Err(e.into());
+        }
+    }
+
+    let db_name = "redis-enterprise-example";
+    let db_port: u16 = 12000;
+    let db_password = env::var("REDIS_ENTERPRISE_DB_PASSWORD")
+        .unwrap_or_else(|_| "example-Redis123!".to_string());
+
+    // Step 2: Create a small database via the typed builder.
+    println!("Step 2: creating database \"{db_name}\" on port {db_port}");
+    let request = CreateDatabaseRequest::builder()
+        .name(db_name)
+        .memory_size(104_857_600) // 100 MiB
+        .port(db_port)
+        .replication(false)
+        .persistence("aof")
+        .eviction_policy("volatile-lru")
+        .authentication_redis_pass(&db_password)
+        .build();
+
+    let created = client.databases().create(request).await?;
+    let uid = created.uid;
+    println!("  ✓ created uid={uid}, status={:?}\n", created.status);
+
+    // Step 3: Poll until the new database goes active (or give up after ~30s).
+    println!("Step 3: waiting for database to become active");
+    let active = {
+        let mut info = created;
+        for _ in 0..15 {
+            if info.status.as_deref() == Some("active") {
+                break;
+            }
+            tokio::time::sleep(Duration::from_secs(2)).await;
+            info = client.databases().info(uid).await?;
+        }
+        info
+    };
+    println!(
+        "  ✓ status={:?}, memory_size={} bytes, port={:?}\n",
+        active.status,
+        active.memory_size.unwrap_or(0),
+        active.port
+    );
+
+    // Step 4: List all databases.
+    println!("Step 4: listing databases");
+    for db in client.databases().list().await? {
+        println!("  - {} (uid {}, port {:?})", db.name, db.uid, db.port);
+    }
     println!();
 
-    // Create client
-    let client = EnterpriseClient::builder()
-        .base_url(&base_url)
-        .username(&username)
-        .password(&password)
-        .insecure(insecure)
-        .build()?;
+    // Step 5: Clean up.
+    println!("Step 5: deleting \"{db_name}\"");
+    client.databases().delete(uid).await?;
+    println!("  ✓ deleted uid={uid}\n");
 
-    // Step 1: Check cluster status using raw API
-    println!("Step 1: Checking cluster status...");
-    match client.get::<serde_json::Value>("/v1/cluster").await {
-        Ok(cluster) => {
-            if let Some(name) = cluster.get("name") {
-                println!("✓ Cluster is initialized: {}", name);
-            }
-        }
-        Err(e) => {
-            println!("⚠ Cluster check failed: {}", e);
-            println!("→ You may need to bootstrap the cluster first");
-        }
-    }
-
-    // Step 2: Create a database using raw API
-    println!("\nStep 2: Creating database...");
-
-    let db_request = json!({
-        "name": "test-database",
-        "memory_size": 104857600, // 100 MB
-        "port": 12000,
-        "replication": false,
-        "persistence": "aof",
-        "eviction_policy": "volatile-lru",
-        "authentication_redis_pass": "testpass123"
-    });
-
-    match client
-        .post::<serde_json::Value, serde_json::Value>("/v1/bdbs", &db_request)
-        .await
-    {
-        Ok(db) => {
-            if let Some(uid) = db.get("uid") {
-                println!("✓ Database created with ID: {}", uid);
-
-                // Wait for database to be active
-                println!("→ Waiting for database to become active...");
-                tokio::time::sleep(tokio::time::Duration::from_secs(5)).await;
-
-                // Get database info
-                if let Ok(db_info) = client
-                    .get::<serde_json::Value>(&format!("/v1/bdbs/{}", uid))
-                    .await
-                    && let Some(status) = db_info.get("status")
-                {
-                    println!("✓ Database status: {}", status);
-                }
-            }
-        }
-        Err(e) => {
-            println!("⚠ Database creation failed: {}", e);
-        }
-    }
-
-    // Step 3: List databases using typed handler
-    println!("\nStep 3: Listing databases...");
-    let db_handler = DatabaseHandler::new(client.clone());
-
-    match db_handler.list().await {
-        Ok(databases) => {
-            println!("✓ Found {} database(s):", databases.len());
-            for db in databases {
-                println!("  - {} (ID: {}, Port: {:?})", db.name, db.uid, db.port);
-            }
-        }
-        Err(e) => {
-            println!("⚠ Failed to list databases: {}", e);
-        }
-    }
-
-    // Step 4: Get cluster stats
-    println!("\nStep 4: Cluster statistics...");
-    match client
-        .get::<serde_json::Value>("/v1/cluster/stats/last")
-        .await
-    {
-        Ok(stats) => {
-            println!("✓ Cluster stats retrieved");
-            if let Some(conns) = stats.get("conns") {
-                println!("  Connections: {}", conns);
-            }
-        }
-        Err(e) => {
-            println!("⚠ Could not get stats: {}", e);
-        }
-    }
-
-    println!("\n✓ Setup example complete!");
-    println!("\nNext steps:");
-    println!("1. Connect to your database: redis-cli -p 12000 -a testpass123");
-    println!("2. Explore the API using the client.get() and client.post() methods");
-    println!("3. Use typed handlers for common operations");
+    println!("Done. While the database existed, you could connect with:");
+    println!("  redis-cli -p {db_port} -a <password>");
 
     Ok(())
 }

--- a/examples/crdb_basics.rs
+++ b/examples/crdb_basics.rs
@@ -1,0 +1,82 @@
+//! Read-only Active-Active (CRDB) walkthrough.
+//!
+//! Lists the cluster's CRDBs and, if at least one exists, fetches its details
+//! and runs the per-CRDB health report. Strictly read-only — never creates,
+//! deletes, flushes, or purges anything.
+//!
+//! Run with:
+//! ```bash
+//! REDIS_ENTERPRISE_URL=... REDIS_ENTERPRISE_USER=... REDIS_ENTERPRISE_PASSWORD=... \
+//!   REDIS_ENTERPRISE_INSECURE=true \
+//!   cargo run --example crdb_basics
+//! ```
+//!
+//! The flush / purge / updates endpoints exposed by `client.crdb()` are
+//! destructive against a live multi-region deployment; see
+//! `docs/api-inventory.csv` and the rustdocs for those operations.
+
+use redis_enterprise::EnterpriseClient;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let client = EnterpriseClient::from_env()?;
+
+    println!("Active-Active (CRDB) walkthrough — read-only");
+    println!("==============================================\n");
+
+    let crdbs = client.crdb().list().await?;
+
+    if crdbs.is_empty() {
+        println!("No Active-Active databases configured on this cluster.");
+        println!("Create one through the Admin UI or `client.crdb().create(...)`");
+        println!("before re-running this example to see the per-CRDB sections.");
+        return Ok(());
+    }
+
+    println!("Found {} CRDB(s):\n", crdbs.len());
+    for crdb in &crdbs {
+        println!(
+            "  - {} (guid {}, status {}, {} instance(s))",
+            crdb.name,
+            crdb.guid,
+            crdb.status,
+            crdb.instances.len()
+        );
+    }
+    println!();
+
+    // Pick the first CRDB and explore it in more detail.
+    let first = &crdbs[0];
+    println!("Details for \"{}\" (guid {}):", first.name, first.guid);
+    let detailed = client.crdb().get(&first.guid).await?;
+    println!("  memory_size: {} bytes", detailed.memory_size);
+    println!(
+        "  encryption: {}",
+        detailed
+            .encryption
+            .map(|b| b.to_string())
+            .unwrap_or_else(|| "(unset)".into())
+    );
+    println!(
+        "  data_persistence: {}",
+        detailed.data_persistence.as_deref().unwrap_or("(unset)")
+    );
+
+    println!("\n  instances:");
+    for instance in &detailed.instances {
+        println!(
+            "    - id {}, cluster {} ({:?}), status {}",
+            instance.id, instance.cluster, instance.cluster_name, instance.status
+        );
+    }
+
+    // The /health_report endpoint shipped in v0.9.0. It can return a rich,
+    // version-specific document so we print it as raw JSON.
+    println!("\n  health report:");
+    match client.crdb().health_report(&first.guid).await {
+        Ok(report) => println!("{}", serde_json::to_string_pretty(&report)?),
+        Err(e) => eprintln!("    ⚠ health_report failed: {e}"),
+    }
+
+    Ok(())
+}

--- a/examples/database_actions.rs
+++ b/examples/database_actions.rs
@@ -1,0 +1,93 @@
+//! Read-only tour of database action endpoints.
+//!
+//! Picks the first database on the cluster and demonstrates the
+//! status-and-availability action endpoints that don't mutate state:
+//! `availability`, `endpoint_availability`, `recover_status`,
+//! `optimize_shards_placement` (status), and `metrics`.
+//!
+//! Destructive actions (`recover`, `export`, `import`, `flush`,
+//! `upgrade_redis_version`, `reset_admin_pass`, `stop_traffic`,
+//! `resume_traffic`) are intentionally NOT exercised by this example —
+//! they're documented on `client.databases()` and the rustdocs explain
+//! the per-method contract.
+//!
+//! Run with:
+//! ```bash
+//! REDIS_ENTERPRISE_URL=... REDIS_ENTERPRISE_USER=... REDIS_ENTERPRISE_PASSWORD=... \
+//!   REDIS_ENTERPRISE_INSECURE=true \
+//!   cargo run --example database_actions
+//! ```
+
+use redis_enterprise::EnterpriseClient;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let client = EnterpriseClient::from_env()?;
+
+    println!("Database actions tour — read-only");
+    println!("==================================\n");
+
+    let databases = client.databases().list().await?;
+    let Some(db) = databases.first() else {
+        println!("No databases on this cluster. Run the `cluster_setup_simple`");
+        println!("example first to create a disposable one.");
+        return Ok(());
+    };
+
+    let uid = db.uid;
+    println!("Inspecting database \"{}\" (uid {})", db.name, uid);
+    println!(
+        "  status={:?}, memory_size={} bytes, port={:?}\n",
+        db.status,
+        db.memory_size.unwrap_or(0),
+        db.port
+    );
+
+    // availability — whether the bdb is reachable on the data plane
+    println!("availability:");
+    match client.databases().availability(uid).await {
+        Ok(v) => println!("  {}", serde_json::to_string(&v)?),
+        Err(e) => eprintln!("  ⚠ {e}"),
+    }
+
+    // endpoint_availability — same check, scoped to the endpoint shape
+    println!("\nendpoint_availability:");
+    match client.databases().endpoint_availability(uid).await {
+        Ok(v) => println!("  {}", serde_json::to_string(&v)?),
+        Err(e) => eprintln!("  ⚠ {e}"),
+    }
+
+    // recover_status — status of any in-flight recovery
+    println!("\nrecover_status:");
+    match client.databases().recover_status(uid).await {
+        Ok(v) => println!("  {}", serde_json::to_string(&v)?),
+        Err(e) => eprintln!("  ⚠ {e}"),
+    }
+
+    // optimize_shards_placement — status of the placement optimizer
+    println!("\noptimize_shards_placement (status):");
+    match client.databases().optimize_shards_placement(uid).await {
+        Ok(v) => println!("  {}", serde_json::to_string(&v)?),
+        Err(e) => eprintln!("  ⚠ {e}"),
+    }
+
+    // metrics — last metrics snapshot for the database
+    println!("\nmetrics:");
+    match client.databases().metrics(uid).await {
+        Ok(v) => {
+            let s = serde_json::to_string(&v)?;
+            let preview = s.chars().take(200).collect::<String>();
+            println!(
+                "  {preview}{}",
+                if s.len() > 200 { " …(truncated)" } else { "" }
+            );
+        }
+        Err(e) => eprintln!("  ⚠ {e}"),
+    }
+
+    println!("\nDone. To run destructive actions, see the per-method rustdoc on");
+    println!("`client.databases()` — for example `flush`, `recover`, or");
+    println!("`upgrade_redis_version`.");
+
+    Ok(())
+}

--- a/src/crdb.rs
+++ b/src/crdb.rs
@@ -106,7 +106,7 @@ pub struct CreateCrdbInstance {
     /// Cluster fully qualified name, used to uniquely identify the cluster
     #[builder(setter(into))]
     pub cluster: String,
-    /// Cluster access URL (e.g., 'https://cluster1.example.com:9443')
+    /// Cluster access URL (for example `https://cluster1.example.com:9443`)
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(default, setter(into, strip_option))]
     pub cluster_url: Option<String>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,7 +21,7 @@
 //! Add to your `Cargo.toml`:
 //! ```toml
 //! [dependencies]
-//! redis-enterprise = "0.8.7"
+//! redis-enterprise = "0.9"
 //! tokio = { version = "1", features = ["full"] }
 //! ```
 //!

--- a/src/users.rs
+++ b/src/users.rs
@@ -5,9 +5,8 @@
 //! - Create and update configurations
 //! - Monitor status and metrics
 //!
-//! Example
-//! ```no_run
-//! ```
+//! See [`UserHandler`] for the full API. For a worked CRUD example use
+//! [`CreateUserRequest`] alongside `client.users().create(...)`.
 
 use crate::client::RestClient;
 use crate::error::Result;


### PR DESCRIPTION
## Summary

A pre-release sweep that brings the user-facing surface back in line with what the crate actually exposes after the audit + Tier-1 round, so v0.9.0 ships with accurate docs and modern examples.

### README

- Bump installation snippet from `0.8.7` to `0.9`.
- **Quick Start** now leads with `EnterpriseClient::from_env()` and shows field-level usage that actually compiles against the current types (`cluster.name: String`, `node.addr: Option<String>`, etc.).
- Link to the `examples/` directory.
- **Trim the Python section** — the bulleted Python API list was stale, the publish workflow has been broken since the `reqwest 0.13` upgrade (#25), and the binding scope is still being scoped under #51. Point at `python/README.md` with a clear "treat as experimental" note instead.
- Move **Environment Variables** out of the Python subtree where it belonged on the Rust client all along.
- **Soften the "100% coverage" claim** — after the audit it's "comprehensive coverage of the documented surface" with links to `docs/api-inventory.csv` and `docs/api-gap-triage.md` for the source-of-truth listings.

### `src/lib.rs`

- Same `0.8.7` → `0.9` version bump in the crate-level Quick Start.

### Examples

| File | Status |
|---|---|
| `basic_enterprise.rs` | Unchanged — already modern fluent API. |
| `cluster_setup_simple.rs` | Rewritten to use the typed fluent API throughout (`client.cluster().info()`, `client.databases().create(CreateDatabaseRequest::builder()...)`, `client.databases().info()`, `delete()`), poll until the database goes active, and **clean up** the resource it creates. Password is now read from `REDIS_ENTERPRISE_DB_PASSWORD` rather than hardcoded in source. |
| `crdb_basics.rs` | **New.** Strictly read-only walkthrough of the CRDB endpoints, including the v0.9.0 `health_report`. |
| `database_actions.rs` | **New.** Read-only tour of `availability`, `endpoint_availability`, `recover_status`, `optimize_shards_placement`, and `metrics`. Destructive partners are intentionally not exercised; per-method rustdocs explain those contracts. |

### Drive-by rustdoc fixes

Two pre-existing rustdoc warnings that had been drifting because CI doesn't enforce `-D warnings` on `cargo doc`:

- `src/crdb.rs:109` — `'https://...'` parsed as a bare URL warning; reworded with a code-fenced example URL.
- `src/users.rs:1-10` — module-level doc had an empty `no_run` code block triggering "Rust code block is empty"; replaced with a short pointer to `UserHandler` / `CreateUserRequest`.

`RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps` now passes clean.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace`
- [x] `cargo build --examples` (basic_enterprise, cluster_setup_simple, crdb_basics, database_actions all compile)
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps` — clean
