### PR TITLE
chore: release v0.9.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.1](https://github.com/redis-developer/redis-enterprise-rs/compare/v0.9.0...v0.9.1) - 2026-06-02
+
+### Other
+
+- *(python)* add behavioral coverage for the Python bindings ([#100](https://github.com/redis-developer/redis-enterprise-rs/pull/100))
+- *(python)* define bindings scope and parity strategy ([#51](https://github.com/redis-developer/redis-enterprise-rs/pull/51)) ([#99](https://github.com/redis-developer/redis-enterprise-rs/pull/99))
+
 ## [0.9.0](https://github.com/redis-developer/redis-enterprise-rs/compare/v0.8.7...v0.9.0) - 2026-05-26
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1158,7 +1158,7 @@ dependencies = [
 
 [[package]]
 name = "redis-enterprise"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "redis-enterprise"
-version = "0.9.0"
+version = "0.9.1"
 edition = "2024"
 rust-version = "1.89"
 authors = ["Josh Rotenberg <josh.rotenberg@redis.com>"]


### PR DESCRIPTION



## 🤖 New release

* `redis-enterprise`: 0.9.0 -> 0.9.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.9.1](https://github.com/redis-developer/redis-enterprise-rs/compare/v0.9.0...v0.9.1) - 2026-06-02

### Other

- *(python)* add behavioral coverage for the Python bindings ([#100](https://github.com/redis-developer/redis-enterprise-rs/pull/100))
- *(python)* define bindings scope and parity strategy ([#51](https://github.com/redis-developer/redis-enterprise-rs/pull/51)) ([#99](https://github.com/redis-developer/redis-enterprise-rs/pull/99))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).