### PR TITLE
chore: release v0.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.10.0](https://github.com/redis-developer/redis-enterprise-rs/compare/v0.9.1...v0.10.0) - 2026-08-04
+
+### Added
+
+- *(api)* refresh inventory and add current Enterprise routes ([#110](https://github.com/redis-developer/redis-enterprise-rs/pull/110))
+
+### Fixed
+
+- harden supported-version contract matrix ([#127](https://github.com/redis-developer/redis-enterprise-rs/pull/127))
+- *(api)* handle empty and streamed response bodies ([#120](https://github.com/redis-developer/redis-enterprise-rs/pull/120))
+- *(bdb)* support Redis version selection ([#118](https://github.com/redis-developer/redis-enterprise-rs/pull/118))
+
+### Other
+
+- add coverage and dependency quality gates ([#123](https://github.com/redis-developer/redis-enterprise-rs/pull/123))
+- *(api)* automate docs drift and supported-version compliance ([#122](https://github.com/redis-developer/redis-enterprise-rs/pull/122))
+- *(models)* validate typed models against observed payloads ([#121](https://github.com/redis-developer/redis-enterprise-rs/pull/121))
+- *(api)* classify non-inventory Enterprise routes ([#117](https://github.com/redis-developer/redis-enterprise-rs/pull/117))
+- *(coverage)* make Enterprise API audit behavioral ([#113](https://github.com/redis-developer/redis-enterprise-rs/pull/113))
+- *(compliance)* add versioned Enterprise REST matrix ([#112](https://github.com/redis-developer/redis-enterprise-rs/pull/112))
+- *(api)* define Redis Software version support ([#111](https://github.com/redis-developer/redis-enterprise-rs/pull/111))
+
 ## [0.9.1](https://github.com/redis-developer/redis-enterprise-rs/compare/v0.9.0...v0.9.1) - 2026-06-02
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1179,7 +1179,7 @@ dependencies = [
 
 [[package]]
 name = "redis-enterprise"
-version = "0.9.1"
+version = "0.10.0"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "redis-enterprise"
-version = "0.9.1"
+version = "0.10.0"
 edition = "2024"
 rust-version = "1.89"
 authors = ["Josh Rotenberg <josh.rotenberg@redis.com>"]


### PR DESCRIPTION



## 🤖 New release

* `redis-enterprise`: 0.9.1 -> 0.10.0 (⚠ API breaking changes)

### ⚠ `redis-enterprise` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field UsageReport.cluster_uuid in /tmp/.tmpyhjd8O/redis-enterprise-rs/src/usage_report.rs:32
  field UsageReport.date in /tmp/.tmpyhjd8O/redis-enterprise-rs/src/usage_report.rs:35
  field UsageReport.software_version in /tmp/.tmpyhjd8O/redis-enterprise-rs/src/usage_report.rs:38
  field UsageReport.api_version in /tmp/.tmpyhjd8O/redis-enterprise-rs/src/usage_report.rs:41
  field UsageReport.bdb_uid in /tmp/.tmpyhjd8O/redis-enterprise-rs/src/usage_report.rs:44
  field UsageReport.type_ in /tmp/.tmpyhjd8O/redis-enterprise-rs/src/usage_report.rs:47
  field UsageReport.shard_type in /tmp/.tmpyhjd8O/redis-enterprise-rs/src/usage_report.rs:50
  field UsageReport.dominant_shard_criteria in /tmp/.tmpyhjd8O/redis-enterprise-rs/src/usage_report.rs:53
  field UsageReport.provisioned_memory in /tmp/.tmpyhjd8O/redis-enterprise-rs/src/usage_report.rs:56
  field UsageReport.used_memory in /tmp/.tmpyhjd8O/redis-enterprise-rs/src/usage_report.rs:59
  field UsageReport.master_shards_count in /tmp/.tmpyhjd8O/redis-enterprise-rs/src/usage_report.rs:62
  field UsageReport.no_eviction in /tmp/.tmpyhjd8O/redis-enterprise-rs/src/usage_report.rs:65
  field UsageReport.persistence in /tmp/.tmpyhjd8O/redis-enterprise-rs/src/usage_report.rs:68
  field UsageReport.backup in /tmp/.tmpyhjd8O/redis-enterprise-rs/src/usage_report.rs:71
  field UsageReport.using_redis_search in /tmp/.tmpyhjd8O/redis-enterprise-rs/src/usage_report.rs:74
  field UsageReport.ops_sec in /tmp/.tmpyhjd8O/redis-enterprise-rs/src/usage_report.rs:77
  field UsageReport.replication in /tmp/.tmpyhjd8O/redis-enterprise-rs/src/usage_report.rs:80
  field UsageReport.active_active in /tmp/.tmpyhjd8O/redis-enterprise-rs/src/usage_report.rs:83
  field UsageReport.license in /tmp/.tmpyhjd8O/redis-enterprise-rs/src/usage_report.rs:86
  field UsageReport.additional_fields in /tmp/.tmpyhjd8O/redis-enterprise-rs/src/usage_report.rs:89
  field UsageReport.cluster_uuid in /tmp/.tmpyhjd8O/redis-enterprise-rs/src/usage_report.rs:32
  field UsageReport.date in /tmp/.tmpyhjd8O/redis-enterprise-rs/src/usage_report.rs:35
  field UsageReport.software_version in /tmp/.tmpyhjd8O/redis-enterprise-rs/src/usage_report.rs:38
  field UsageReport.api_version in /tmp/.tmpyhjd8O/redis-enterprise-rs/src/usage_report.rs:41
  field UsageReport.bdb_uid in /tmp/.tmpyhjd8O/redis-enterprise-rs/src/usage_report.rs:44
  field UsageReport.type_ in /tmp/.tmpyhjd8O/redis-enterprise-rs/src/usage_report.rs:47
  field UsageReport.shard_type in /tmp/.tmpyhjd8O/redis-enterprise-rs/src/usage_report.rs:50
  field UsageReport.dominant_shard_criteria in /tmp/.tmpyhjd8O/redis-enterprise-rs/src/usage_report.rs:53
  field UsageReport.provisioned_memory in /tmp/.tmpyhjd8O/redis-enterprise-rs/src/usage_report.rs:56
  field UsageReport.used_memory in /tmp/.tmpyhjd8O/redis-enterprise-rs/src/usage_report.rs:59
  field UsageReport.master_shards_count in /tmp/.tmpyhjd8O/redis-enterprise-rs/src/usage_report.rs:62
  field UsageReport.no_eviction in /tmp/.tmpyhjd8O/redis-enterprise-rs/src/usage_report.rs:65
  field UsageReport.persistence in /tmp/.tmpyhjd8O/redis-enterprise-rs/src/usage_report.rs:68
  field UsageReport.backup in /tmp/.tmpyhjd8O/redis-enterprise-rs/src/usage_report.rs:71
  field UsageReport.using_redis_search in /tmp/.tmpyhjd8O/redis-enterprise-rs/src/usage_report.rs:74
  field UsageReport.ops_sec in /tmp/.tmpyhjd8O/redis-enterprise-rs/src/usage_report.rs:77
  field UsageReport.replication in /tmp/.tmpyhjd8O/redis-enterprise-rs/src/usage_report.rs:80
  field UsageReport.active_active in /tmp/.tmpyhjd8O/redis-enterprise-rs/src/usage_report.rs:83
  field UsageReport.license in /tmp/.tmpyhjd8O/redis-enterprise-rs/src/usage_report.rs:86
  field UsageReport.additional_fields in /tmp/.tmpyhjd8O/redis-enterprise-rs/src/usage_report.rs:89
  field CreateDatabaseRequest.redis_version in /tmp/.tmpyhjd8O/redis-enterprise-rs/src/bdb.rs:664
  field CreateDatabaseRequest.redis_version in /tmp/.tmpyhjd8O/redis-enterprise-rs/src/bdb.rs:664

--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/enum_variant_added.ron

Failed in:
  variant RestError:UnsupportedOperation in /tmp/.tmpyhjd8O/redis-enterprise-rs/src/error.rs:88
  variant RestError:UnsupportedOperation in /tmp/.tmpyhjd8O/redis-enterprise-rs/src/error.rs:88

--- failure struct_marked_non_exhaustive: struct marked #[non_exhaustive] ---

Description:
A public struct has been marked #[non_exhaustive], which will prevent it from being constructed using a struct literal outside of its crate. It previously had no private fields, so a struct literal could be used to construct it outside its crate.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#attr-adding-non-exhaustive
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/struct_marked_non_exhaustive.ron

Failed in:
  struct DatabaseInfo in /tmp/.tmpyhjd8O/redis-enterprise-rs/src/bdb.rs:193
  struct DatabaseInfo in /tmp/.tmpyhjd8O/redis-enterprise-rs/src/bdb.rs:193
  struct DatabaseInfo in /tmp/.tmpyhjd8O/redis-enterprise-rs/src/bdb.rs:193
  struct License in /tmp/.tmpyhjd8O/redis-enterprise-rs/src/license.rs:18
  struct License in /tmp/.tmpyhjd8O/redis-enterprise-rs/src/license.rs:18
  struct User in /tmp/.tmpyhjd8O/redis-enterprise-rs/src/users.rs:21
  struct User in /tmp/.tmpyhjd8O/redis-enterprise-rs/src/users.rs:21
  struct ClusterInfo in /tmp/.tmpyhjd8O/redis-enterprise-rs/src/cluster.rs:84
  struct ClusterInfo in /tmp/.tmpyhjd8O/redis-enterprise-rs/src/cluster.rs:84
  struct Node in /tmp/.tmpyhjd8O/redis-enterprise-rs/src/nodes.rs:27
  struct Node in /tmp/.tmpyhjd8O/redis-enterprise-rs/src/nodes.rs:27
  struct Shard in /tmp/.tmpyhjd8O/redis-enterprise-rs/src/shards.rs:41
  struct Shard in /tmp/.tmpyhjd8O/redis-enterprise-rs/src/shards.rs:41
  struct EndpointInfo in /tmp/.tmpyhjd8O/redis-enterprise-rs/src/bdb.rs:591

--- failure struct_missing: pub struct removed or renamed ---

Description:
A publicly-visible struct cannot be imported by its prior path. A `pub use` may have been removed, or the struct itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/struct_missing.ron

Failed in:
  struct redis_enterprise::usage_report::DatabaseUsage, previously in file /tmp/.tmpVZOQXH/redis-enterprise/src/usage_report.rs:42
  struct redis_enterprise::DatabaseUsage, previously in file /tmp/.tmpVZOQXH/redis-enterprise/src/usage_report.rs:42
  struct redis_enterprise::usage_report::UsageSummary, previously in file /tmp/.tmpVZOQXH/redis-enterprise/src/usage_report.rs:77
  struct redis_enterprise::UsageSummary, previously in file /tmp/.tmpVZOQXH/redis-enterprise/src/usage_report.rs:77
  struct redis_enterprise::usage_report::NodeUsage, previously in file /tmp/.tmpVZOQXH/redis-enterprise/src/usage_report.rs:62
  struct redis_enterprise::NodeUsage, previously in file /tmp/.tmpVZOQXH/redis-enterprise/src/usage_report.rs:62

--- failure struct_pub_field_missing: pub struct's pub field removed or renamed ---

Description:
A publicly-visible struct has at least one public field that is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/struct_pub_field_missing.ron

Failed in:
  field report_id of struct UsageReport, previously in file /tmp/.tmpVZOQXH/redis-enterprise/src/usage_report.rs:20
  field timestamp of struct UsageReport, previously in file /tmp/.tmpVZOQXH/redis-enterprise/src/usage_report.rs:22
  field period_start of struct UsageReport, previously in file /tmp/.tmpVZOQXH/redis-enterprise/src/usage_report.rs:24
  field period_end of struct UsageReport, previously in file /tmp/.tmpVZOQXH/redis-enterprise/src/usage_report.rs:26
  field databases of struct UsageReport, previously in file /tmp/.tmpVZOQXH/redis-enterprise/src/usage_report.rs:31
  field nodes of struct UsageReport, previously in file /tmp/.tmpVZOQXH/redis-enterprise/src/usage_report.rs:34
  field summary of struct UsageReport, previously in file /tmp/.tmpVZOQXH/redis-enterprise/src/usage_report.rs:37
  field report_id of struct UsageReport, previously in file /tmp/.tmpVZOQXH/redis-enterprise/src/usage_report.rs:20
  field timestamp of struct UsageReport, previously in file /tmp/.tmpVZOQXH/redis-enterprise/src/usage_report.rs:22
  field period_start of struct UsageReport, previously in file /tmp/.tmpVZOQXH/redis-enterprise/src/usage_report.rs:24
  field period_end of struct UsageReport, previously in file /tmp/.tmpVZOQXH/redis-enterprise/src/usage_report.rs:26
  field databases of struct UsageReport, previously in file /tmp/.tmpVZOQXH/redis-enterprise/src/usage_report.rs:31
  field nodes of struct UsageReport, previously in file /tmp/.tmpVZOQXH/redis-enterprise/src/usage_report.rs:34
  field summary of struct UsageReport, previously in file /tmp/.tmpVZOQXH/redis-enterprise/src/usage_report.rs:37
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.10.0](https://github.com/redis-developer/redis-enterprise-rs/compare/v0.9.1...v0.10.0) - 2026-08-04

### Added

- *(api)* refresh inventory and add current Enterprise routes ([#110](https://github.com/redis-developer/redis-enterprise-rs/pull/110))

### Fixed

- harden supported-version contract matrix ([#127](https://github.com/redis-developer/redis-enterprise-rs/pull/127))
- *(api)* handle empty and streamed response bodies ([#120](https://github.com/redis-developer/redis-enterprise-rs/pull/120))
- *(bdb)* support Redis version selection ([#118](https://github.com/redis-developer/redis-enterprise-rs/pull/118))

### Other

- add coverage and dependency quality gates ([#123](https://github.com/redis-developer/redis-enterprise-rs/pull/123))
- *(api)* automate docs drift and supported-version compliance ([#122](https://github.com/redis-developer/redis-enterprise-rs/pull/122))
- *(models)* validate typed models against observed payloads ([#121](https://github.com/redis-developer/redis-enterprise-rs/pull/121))
- *(api)* classify non-inventory Enterprise routes ([#117](https://github.com/redis-developer/redis-enterprise-rs/pull/117))
- *(coverage)* make Enterprise API audit behavioral ([#113](https://github.com/redis-developer/redis-enterprise-rs/pull/113))
- *(compliance)* add versioned Enterprise REST matrix ([#112](https://github.com/redis-developer/redis-enterprise-rs/pull/112))
- *(api)* define Redis Software version support ([#111](https://github.com/redis-developer/redis-enterprise-rs/pull/111))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).