### PR TITLE
ci(api): automate docs drift and supported-version compliance

### DIFF
--- a/.github/workflows/enterprise-contract.yml
+++ b/.github/workflows/enterprise-contract.yml
@@ -1,0 +1,177 @@
+name: Enterprise API contract
+
+on:
+  schedule:
+    - cron: "17 6 * * 1"
+  workflow_dispatch:
+    inputs:
+      run_docs:
+        description: Crawl official Redis request docs and compare the checked inventory
+        required: true
+        default: true
+        type: boolean
+      run_live:
+        description: Run safe live compliance against every supported Redis Software family
+        required: true
+        default: true
+        type: boolean
+      run_disposable_writes:
+        description: Also run self-cleaning write lifecycles (manual dispatch only)
+        required: true
+        default: false
+        type: boolean
+
+permissions:
+  contents: read
+
+concurrency:
+  group: enterprise-api-contract
+  cancel-in-progress: false
+
+jobs:
+  docs-inventory:
+    name: Official docs inventory drift
+    if: github.event_name == 'schedule' || inputs.run_docs
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Prepare artifact directory
+        run: mkdir -p target/contract-artifacts
+
+      - name: Crawl official request documentation
+        id: crawl
+        continue-on-error: true
+        run: >-
+          python3 scripts/export_api_inventory.py
+          --output target/contract-artifacts/fresh-api-inventory.csv
+          --status-output target/contract-artifacts/docs-crawl-status.json
+
+      - name: Compare normalized method and path sets
+        id: compare
+        if: steps.crawl.outcome == 'success'
+        continue-on-error: true
+        run: >-
+          python3 scripts/check_api_inventory_drift.py
+          --expected docs/api-inventory.csv
+          --actual target/contract-artifacts/fresh-api-inventory.csv
+          --crawl-status target/contract-artifacts/docs-crawl-status.json
+          --report target/contract-artifacts/api-inventory-drift.md
+          --status-output target/contract-artifacts/api-inventory-drift.json
+
+      - name: Publish drift job summary
+        if: always() && steps.compare.outcome != 'skipped'
+        run: cat target/contract-artifacts/api-inventory-drift.md >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Publish crawl failure summary
+        if: always() && steps.crawl.outcome == 'failure'
+        run: |
+          {
+            echo "## Official Redis API inventory crawl"
+            echo
+            echo "The crawl failed before semantic comparison. The status artifact classifies this as a fetch, parse, or local-output failure; it is not reported as an API removal."
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload docs contract artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: official-docs-contract-${{ github.run_id }}
+          path: target/contract-artifacts/
+          if-no-files-found: error
+          retention-days: 30
+
+      - name: Enforce docs contract result
+        if: always()
+        run: |
+          test "${{ steps.crawl.outcome }}" = "success"
+          test "${{ steps.compare.outcome }}" = "success"
+
+  live-compliance:
+    name: Redis Software ${{ matrix.family }} (${{ inputs.run_disposable_writes && 'writes' || 'safe' }})
+    if: github.event_name == 'schedule' || inputs.run_live
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - family: "8.2"
+            image: redislabs/redis:8.2.0-25.12
+            expected_version: 8.2.0-25
+          - family: "8.0"
+            image: redislabs/redis:8.0.20-68.25
+            expected_version: 8.0.20-68
+          - family: "7.22"
+            image: redislabs/redis:7.22.2-170
+            expected_version: 7.22.2-170
+          - family: "7.8"
+            image: redislabs/redis:7.8.6-286
+            expected_version: 7.8.6-286
+          - family: "7.4"
+            image: redislabs/redis:7.4.6-272
+            expected_version: 7.4.6-272
+    env:
+      REDIS_ENTERPRISE_IMAGE: ${{ matrix.image }}
+      REDIS_ENTERPRISE_URL: https://localhost:9443
+      REDIS_ENTERPRISE_USER: admin@redis.local
+      REDIS_ENTERPRISE_PASSWORD: Redis123!
+      REDIS_ENTERPRISE_INSECURE: "true"
+      REDIS_ENTERPRISE_EXPECTED_VERSION: ${{ matrix.expected_version }}
+      COMPLIANCE_PROFILE: ${{ github.event_name == 'workflow_dispatch' && inputs.run_disposable_writes && 'writes' || 'safe' }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo
+        uses: Swatinem/rust-cache@v2
+
+      - name: Pull pinned Enterprise and initializer images
+        run: docker compose --profile init pull redis-enterprise init
+
+      - name: Start pinned Redis Software
+        run: docker compose up -d redis-enterprise
+
+      - name: Initialize disposable cluster and database
+        run: docker compose --profile init up --exit-code-from init init
+
+      - name: Run versioned compliance profile
+        id: compliance
+        run: |
+          mkdir -p target/contract-artifacts
+          if [[ "$COMPLIANCE_PROFILE" == "writes" ]]; then
+            export REDIS_ENTERPRISE_LIVE_WRITES=true
+          fi
+          export REDIS_ENTERPRISE_COMPLIANCE_OUTPUT="target/contract-artifacts/enterprise-compliance-${{ matrix.family }}-${COMPLIANCE_PROFILE}.json"
+          cargo test --test live_compliance live_inventory_compliance -- --ignored --nocapture --test-threads=1
+
+      - name: Render sanitized compliance summary
+        id: summarize
+        if: always() && steps.compliance.outcome == 'success'
+        run: >-
+          python3 scripts/summarize_live_compliance.py
+          --input "target/contract-artifacts/enterprise-compliance-${{ matrix.family }}-${COMPLIANCE_PROFILE}.json"
+          --output "target/contract-artifacts/enterprise-compliance-${{ matrix.family }}-${COMPLIANCE_PROFILE}.md"
+          --expected-version "${{ matrix.expected_version }}"
+          --expected-image "${{ matrix.image }}"
+          --profile "$COMPLIANCE_PROFILE"
+
+      - name: Publish compliance job summary
+        if: always() && steps.summarize.outcome == 'success'
+        run: cat "target/contract-artifacts/enterprise-compliance-${{ matrix.family }}-${COMPLIANCE_PROFILE}.md" >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload sanitized compliance artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: enterprise-compliance-${{ matrix.family }}-${{ env.COMPLIANCE_PROFILE }}-${{ github.run_id }}
+          path: target/contract-artifacts/
+          if-no-files-found: warn
+          retention-days: 30
+
+      - name: Remove disposable cluster and volumes
+        if: always()
+        run: docker compose --profile init down -v

--- a/README.md
+++ b/README.md
@@ -179,6 +179,7 @@ public-doc inventory. The earlier docs-only triage remains available as
 - [Version support and compatibility policy](docs/version-support.md)
 - [Local live-validation runbook](docs/live-validation.md) — bring up a disposable Redis Enterprise cluster via Docker Compose for SDK validation against the real API.
 - [Model-fidelity evidence](docs/model-fidelity.md) — documented fields, sanitized cross-version fixtures, lossless additive-field handling, and exact request wire shapes.
+- [Enterprise API contract automation](docs/contract-automation.md) — scheduled official-doc drift detection and the disposable supported-version live matrix.
 - [Non-inventory route evidence](docs/non-inventory-route-evidence.md) — versioned live dispositions for SDK method/path pairs absent from the public-doc inventory.
 
 ## License

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,7 @@
 #   REDIS_ENTERPRISE_DB_PORT - Host port mapped to the default database port (default: 12000)
 #   REDIS_ENTERPRISE_API_PORT - Host port mapped to the REST API (default: 9443)
 #   REDIS_ENTERPRISE_UI_PORT - Host port mapped to the admin UI (default: 8443)
+#   REDISCTL_IMAGE - Cluster initializer image (defaults to the reviewed digest below)
 #
 # After initialization:
 #   API:      https://localhost:9443 (admin@redis.local / Redis123!)
@@ -34,7 +35,7 @@ services:
       start_period: 10s
 
   init:
-    image: ghcr.io/redis-developer/redisctl:latest
+    image: ${REDISCTL_IMAGE:-ghcr.io/redis-developer/redisctl@sha256:2d8b5148226705ae4c057611c4adcd2c9ba08cac0c02cec1c449fc31b92a2026}
     depends_on:
       redis-enterprise:
         condition: service_healthy

--- a/docs/api-inventory.md
+++ b/docs/api-inventory.md
@@ -52,6 +52,12 @@ Or write to a custom path:
 python3 scripts/export_api_inventory.py --output docs/api-inventory.csv
 ```
 
+The weekly [Enterprise API contract workflow](./contract-automation.md) writes
+the crawl to a temporary artifact and compares normalized method/path sets. It
+never overwrites this reviewed inventory. Fetch, parse, local-output, CSV, and
+semantic-drift failures are classified separately so an external outage cannot
+masquerade as API removal.
+
 ## Audit SDK And Test Evidence
 
 The generated coverage audit deduplicates the inventory by normalized HTTP

--- a/docs/contract-automation.md
+++ b/docs/contract-automation.md
@@ -1,0 +1,104 @@
+# Enterprise API Contract Automation
+
+The `Enterprise API contract` GitHub Actions workflow makes external Redis
+Software contract drift visible without making pull-request CI depend on the
+network, Docker Hub, or a live cluster.
+
+## Cadence and ownership
+
+The workflow runs every Monday at 06:17 UTC and can also be dispatched
+manually. The redis-enterprise-rs maintainers own the result and should triage
+a failed scheduled run within two business days. Artifacts are retained for 30
+days so a transient external failure can be compared with a rerun.
+
+Pull-request CI remains credential-free and deterministic. It runs unit tests
+for the crawler, comparison, failure classification, and summary renderer, but
+never fetches official docs or starts Redis Software.
+
+## Official-doc inventory drift
+
+The docs job performs three separate stages:
+
+1. Crawl the official Redis Software request reference into a temporary CSV.
+2. Compare the fresh and checked-in inventories by normalized HTTP method and
+   path.
+3. Upload the fresh CSV, machine-readable status, and Markdown drift report.
+
+Descriptions, page order, duplicate rows, query strings, trailing slashes, and
+placeholder names do not create route drift. The status artifacts distinguish:
+
+- `fetch_failure`: the official source could not be reached (exporter exit 2);
+- `parse_failure`: pages were fetched but no usable inventory was parsed, or a
+  previously inventoried page yielded no method table (exit 3);
+- `local_failure`: the runner could not write its artifacts (exporter exit 4);
+- `comparison_failure`: either CSV was malformed (comparison exit 3);
+- `semantic_drift`: normalized method/path operations were added or removed
+  (comparison exit 1).
+
+An outage therefore cannot appear as a mass API removal: semantic comparison
+does not run unless the crawl succeeds. The crawl status also records pages
+with no parsed method table; if a page that supplied checked-in routes moves to
+that list, comparison reports a parser failure before calculating removals.
+
+Some macOS framework Python installations do not inherit the system CA store.
+For local crawls, point `SSL_CERT_FILE` at a trusted CA bundle (for example one
+managed by `certifi`) rather than disabling certificate verification. GitHub's
+Ubuntu runners use their system trust store.
+
+### Responding to docs drift
+
+1. Rerun once to rule out a transient fetch failure.
+2. For a parser failure, inspect the fresh page layout and update parser tests
+   before changing the checked inventory.
+3. For semantic drift, review every added and removed operation in the Markdown
+   artifact against the official version-specific references.
+4. Regenerate `docs/api-inventory.csv`, run the method-aware coverage audit,
+   and file or link implementation issues for real contract changes.
+5. Commit the reviewed inventory and generated audit together. Never copy a
+   failed or partial crawl into the repository.
+
+## Supported-version live matrix
+
+The live job starts one isolated disposable Docker stack for each image pinned
+in the [version support policy](./version-support.md): 8.2, 8.0, 7.22, 7.8,
+and 7.4. Each matrix runner:
+
+- pulls the exact Redis Software image;
+- initializes a local cluster and default database with the immutable redisctl
+  image digest checked into `docker-compose.yml`;
+- runs the versioned compliance baseline;
+- verifies that the report's product version and image match the matrix;
+- uploads sanitized JSON and Markdown summaries; and
+- removes containers, networks, and volumes even when a step fails.
+
+Scheduled runs use the safe read-only profile. Self-cleaning write lifecycles
+can run only when a maintainer manually dispatches the workflow with
+`run_disposable_writes` enabled. The workflow has no shared-cluster URL or
+credential inputs and never targets production. Destructive cluster operations
+are not part of this workflow; adding one requires a separate explicit dispatch
+guard and safety review.
+
+The report contains operation status, model field paths, exact image/version
+provenance, and sanitized error classes. It never stores response bodies,
+credentials, license values, resource identifiers, or customer data.
+
+### Responding to live failures
+
+Use the failed step to separate infrastructure from contract behavior:
+
+- image-pull failures are registry or image-availability incidents;
+- initialization failures are disposable-cluster bootstrap defects;
+- version mismatches mean the image pin no longer packages the expected build;
+- compliance failures identify operation, status, or typed-model drift in the
+  sanitized report.
+
+Do not weaken a baseline simply to make a scheduled run green. Reproduce the
+failure against the same pinned image, review official version-specific docs,
+then update code or record a narrowly justified version difference.
+
+## Manual dispatch
+
+From the GitHub Actions page, choose `Enterprise API contract` and `Run
+workflow`. `run_docs` and `run_live` can be selected independently.
+`run_disposable_writes` is off by default and only affects manually dispatched
+live jobs.

--- a/docs/live-validation.md
+++ b/docs/live-validation.md
@@ -36,6 +36,10 @@ The compose file defaults to:
 - `REDIS_ENTERPRISE_UI_PORT=8443`
 - `REDIS_ENTERPRISE_DB_PORT=12000`
 
+The initializer also defaults to an immutable reviewed redisctl image digest.
+Set `REDISCTL_IMAGE` only when intentionally validating a newer initializer;
+scheduled contract runs use the checked-in digest.
+
 You can override the host ports to avoid collisions with an existing local
 cluster:
 
@@ -62,7 +66,11 @@ as the same service definition.
 ## Required Version Matrix
 
 Release validation uses the exact images in the
-[version support policy](./version-support.md):
+[version support policy](./version-support.md).
+
+The weekly [Enterprise API contract workflow](./contract-automation.md) runs
+the safe compliance profile against this entire matrix. This local runbook is
+still the reproduction path and is used for focused write or debugging work.
 
 | Family | Image |
 |---|---|

--- a/docs/version-support.md
+++ b/docs/version-support.md
@@ -112,8 +112,10 @@ Before publishing a crate release:
 - the support table and container pins must be reviewed against Redis's current
   lifecycle and release notes.
 
-Until the automated multi-version compliance workflow is available, these are
-manual release checks and their results belong in
+The weekly [Enterprise API contract workflow](./contract-automation.md) runs the
+safe profile across the full pinned image matrix and publishes sanitized
+per-version artifacts. Self-cleaning write lifecycles remain an explicit manual
+dispatch option. Release review should inspect the newest scheduled result plus
 [the live-validation log](./live-validation.md).
 
 ## Adding and Retiring Server Versions

--- a/scripts/check_api_inventory_drift.py
+++ b/scripts/check_api_inventory_drift.py
@@ -1,0 +1,233 @@
+#!/usr/bin/env python3
+"""Compare official-doc API inventories by normalized HTTP method and path."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+EXIT_SEMANTIC_DRIFT = 1
+EXIT_COMPARISON_FAILURE = 3
+HTTP_METHODS = {"GET", "POST", "PUT", "PATCH", "DELETE", "HEAD", "OPTIONS"}
+
+
+class InventoryFormatError(RuntimeError):
+    """An inventory CSV is missing required or valid operation fields."""
+
+
+class InventoryPageParseError(InventoryFormatError):
+    """A previously inventoried docs page no longer yielded a method table."""
+
+
+@dataclass(frozen=True, order=True)
+class Operation:
+    method: str
+    path: str
+
+    def display(self) -> str:
+        return f"{self.method} {self.path}"
+
+
+def normalize_path(path: str) -> str:
+    path = path.strip().split("?", 1)[0]
+    path = re.sub(r"\{[^}]+\}|<[^>]+>", "{}", path)
+    if path != "/":
+        path = path.rstrip("/")
+    return path
+
+
+def load_operations(path: Path) -> set[Operation]:
+    try:
+        handle = path.open(newline="", encoding="utf-8")
+    except OSError as exc:
+        raise InventoryFormatError(f"could not read {path}: {type(exc).__name__}") from exc
+
+    with handle:
+        reader = csv.DictReader(handle)
+        if reader.fieldnames is None or not {"method", "path"}.issubset(reader.fieldnames):
+            raise InventoryFormatError(f"{path} must contain method and path columns")
+
+        operations = set()
+        for line_number, row in enumerate(reader, start=2):
+            method = (row.get("method") or "").strip().upper()
+            operation_path = normalize_path(row.get("path") or "")
+            if method not in HTTP_METHODS:
+                raise InventoryFormatError(
+                    f"{path}:{line_number} has unsupported HTTP method {method!r}"
+                )
+            if not operation_path.startswith("/"):
+                raise InventoryFormatError(
+                    f"{path}:{line_number} has invalid API path {operation_path!r}"
+                )
+            operations.add(Operation(method, operation_path))
+
+    if not operations:
+        raise InventoryFormatError(f"{path} contains no operations")
+    return operations
+
+
+def load_expected_pages(path: Path) -> set[str]:
+    try:
+        with path.open(newline="", encoding="utf-8") as handle:
+            reader = csv.DictReader(handle)
+            if reader.fieldnames is None or "page" not in reader.fieldnames:
+                raise InventoryFormatError(f"{path} must contain a page column")
+            pages = {(row.get("page") or "").strip() for row in reader}
+    except OSError as exc:
+        raise InventoryFormatError(f"could not read {path}: {type(exc).__name__}") from exc
+    pages.discard("")
+    if not pages:
+        raise InventoryFormatError(f"{path} contains no source pages")
+    return pages
+
+
+def load_crawl_status(path: Path) -> set[str]:
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise InventoryFormatError(
+            f"could not read crawl status {path}: {type(exc).__name__}"
+        ) from exc
+    if not isinstance(payload, dict) or payload.get("classification") != "success":
+        raise InventoryFormatError(f"{path} is not a successful crawl status")
+    empty_pages = payload.get("pages_without_method_rows")
+    if not isinstance(empty_pages, list) or not all(
+        isinstance(page, str) for page in empty_pages
+    ):
+        raise InventoryFormatError(
+            f"{path} must contain a pages_without_method_rows string array"
+        )
+    return set(empty_pages)
+
+
+def compare(
+    expected: set[Operation], actual: set[Operation]
+) -> tuple[list[Operation], list[Operation]]:
+    return sorted(actual - expected), sorted(expected - actual)
+
+
+def render_report(
+    expected_count: int,
+    actual_count: int,
+    added: list[Operation],
+    removed: list[Operation],
+) -> str:
+    outcome = "semantic drift detected" if added or removed else "no semantic drift"
+    lines = [
+        "# Official Redis API inventory drift",
+        "",
+        f"**Outcome:** {outcome}",
+        "",
+        f"- Checked-in unique operations: `{expected_count}`",
+        f"- Fresh official-doc unique operations: `{actual_count}`",
+        f"- Added by official docs: `{len(added)}`",
+        f"- Removed from official docs: `{len(removed)}`",
+    ]
+
+    for heading, operations in [
+        ("Added by official docs", added),
+        ("Absent from fresh official docs", removed),
+    ]:
+        if not operations:
+            continue
+        lines.extend(["", f"## {heading}", ""])
+        lines.extend(f"- `{operation.display()}`" for operation in operations)
+
+    lines.extend(
+        [
+            "",
+            "Descriptions, page ordering, duplicate rows, trailing slashes, query strings,",
+            "and placeholder names do not affect this comparison.",
+            "",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def write_json(path: Path, payload: dict[str, object]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--expected", required=True, help="Checked-in inventory CSV")
+    parser.add_argument("--actual", required=True, help="Fresh official-doc inventory CSV")
+    parser.add_argument("--crawl-status", required=True, help="Fresh crawl status JSON")
+    parser.add_argument("--report", required=True, help="Markdown drift report path")
+    parser.add_argument("--status-output", required=True, help="Machine-readable JSON status path")
+    args = parser.parse_args()
+
+    report_path = Path(args.report)
+    status_path = Path(args.status_output)
+    try:
+        expected_path = Path(args.expected)
+        expected = load_operations(expected_path)
+        actual = load_operations(Path(args.actual))
+        expected_pages = load_expected_pages(expected_path)
+        pages_without_method_rows = load_crawl_status(Path(args.crawl_status))
+        parser_regressions = sorted(expected_pages & pages_without_method_rows)
+        if parser_regressions:
+            raise InventoryPageParseError(
+                "fresh crawl yielded no method rows for previously inventoried pages: "
+                + ", ".join(parser_regressions)
+            )
+    except InventoryFormatError as exc:
+        classification = (
+            "parse_failure"
+            if isinstance(exc, InventoryPageParseError)
+            else "comparison_failure"
+        )
+        outcome = (
+            "parser failure"
+            if classification == "parse_failure"
+            else "comparison failure"
+        )
+        report_path.parent.mkdir(parents=True, exist_ok=True)
+        report_path.write_text(
+            "# Official Redis API inventory drift\n\n"
+            f"**Outcome:** {outcome}\n\n{exc}\n",
+            encoding="utf-8",
+        )
+        write_json(
+            status_path,
+            {"classification": classification, "message": str(exc)},
+        )
+        print(f"error: inventory comparison failed: {exc}", file=sys.stderr)
+        return EXIT_COMPARISON_FAILURE
+
+    added, removed = compare(expected, actual)
+    report_path.parent.mkdir(parents=True, exist_ok=True)
+    report_path.write_text(
+        render_report(len(expected), len(actual), added, removed), encoding="utf-8"
+    )
+    classification = "semantic_drift" if added or removed else "success"
+    write_json(
+        status_path,
+        {
+            "classification": classification,
+            "expected_operations": len(expected),
+            "actual_operations": len(actual),
+            "added": [operation.display() for operation in added],
+            "removed": [operation.display() for operation in removed],
+        },
+    )
+
+    if added or removed:
+        print(
+            f"Official-doc inventory drift: {len(added)} added, {len(removed)} removed",
+            file=sys.stderr,
+        )
+        return EXIT_SEMANTIC_DRIFT
+
+    print(f"No official-doc route drift across {len(expected)} unique operations")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/export_api_inventory.py
+++ b/scripts/export_api_inventory.py
@@ -5,7 +5,9 @@ from __future__ import annotations
 
 import argparse
 import csv
+import json
 import re
+import ssl
 import sys
 import urllib.error
 import urllib.parse
@@ -17,6 +19,23 @@ DOCS_ROOT = "https://redis.io"
 REQUESTS_PREFIX = "/docs/latest/operate/rs/references/rest-api/requests/"
 REQUESTS_ROOT = urllib.parse.urljoin(DOCS_ROOT, REQUESTS_PREFIX)
 USER_AGENT = "redis-enterprise-rs-api-inventory/0.1"
+
+EXIT_FETCH_FAILURE = 2
+EXIT_PARSE_FAILURE = 3
+EXIT_LOCAL_FAILURE = 4
+
+
+class DocsFetchError(RuntimeError):
+    """The official documentation could not be fetched."""
+
+    def __init__(self, url: str, category: str):
+        super().__init__(f"{category}: {url}")
+        self.url = url
+        self.category = category
+
+
+class DocsParseError(RuntimeError):
+    """Fetched documentation did not contain a usable inventory."""
 
 MODULE_GUESSES = {
     "actions": "actions",
@@ -69,8 +88,21 @@ MODULE_GUESSES = {
 
 def fetch_text(url: str) -> str:
     request = urllib.request.Request(url, headers={"User-Agent": USER_AGENT})
-    with urllib.request.urlopen(request, timeout=20) as response:
-        return response.read().decode("utf-8")
+    try:
+        with urllib.request.urlopen(request, timeout=20) as response:
+            payload = response.read()
+    except urllib.error.HTTPError as exc:
+        raise DocsFetchError(url, f"http_{exc.code}") from exc
+    except urllib.error.URLError as exc:
+        category = "tls" if isinstance(exc.reason, ssl.SSLError) else "network"
+        raise DocsFetchError(url, category) from exc
+    except (TimeoutError, OSError) as exc:
+        raise DocsFetchError(url, "network") from exc
+
+    try:
+        return payload.decode("utf-8")
+    except UnicodeDecodeError as exc:
+        raise DocsParseError(f"official docs response was not UTF-8: {url}") from exc
 
 
 def normalize_page_url(url: str) -> str:
@@ -162,11 +194,12 @@ def parse_method_rows(markdown: str) -> list[tuple[str, str, str]]:
     return rows
 
 
-def export_inventory(output_path: Path) -> tuple[int, int]:
+def export_inventory(output_path: Path) -> tuple[int, int, list[str]]:
     repo_root = Path(__file__).resolve().parent.parent
     src_root = repo_root / "src"
     pages = discover_request_pages()
     records: list[dict[str, str]] = []
+    pages_without_method_rows: list[str] = []
 
     for page_url in pages:
         page_rel = relative_page(page_url)
@@ -174,8 +207,11 @@ def export_inventory(output_path: Path) -> tuple[int, int]:
         title = parse_title(markdown)
         module_guess = MODULE_GUESSES.get(page_rel, "")
         module_exists = str((src_root / f"{module_guess}.rs").exists()).lower() if module_guess else ""
+        method_rows = parse_method_rows(markdown)
+        if not method_rows:
+            pages_without_method_rows.append(page_rel or "_index")
 
-        for method, path, description in parse_method_rows(markdown):
+        for method, path, description in method_rows:
             records.append(
                 {
                     "page": page_rel or "_index",
@@ -191,6 +227,13 @@ def export_inventory(output_path: Path) -> tuple[int, int]:
                     "notes": "",
                 }
             )
+
+    if not pages:
+        raise DocsParseError("official docs crawl discovered no request pages")
+    if not records:
+        raise DocsParseError(
+            "official docs crawl found no method/path rows; the page layout may have changed"
+        )
 
     output_path.parent.mkdir(parents=True, exist_ok=True)
     with output_path.open("w", newline="", encoding="utf-8") as handle:
@@ -214,7 +257,14 @@ def export_inventory(output_path: Path) -> tuple[int, int]:
         writer.writeheader()
         writer.writerows(records)
 
-    return len(pages), len(records)
+    return len(pages), len(records), sorted(pages_without_method_rows)
+
+
+def write_status(path: Path | None, payload: dict[str, object]) -> None:
+    if path is None:
+        return
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
 
 
 def main() -> int:
@@ -224,13 +274,55 @@ def main() -> int:
         default="docs/api-inventory.csv",
         help="Path to the generated CSV file (default: docs/api-inventory.csv)",
     )
+    parser.add_argument(
+        "--status-output",
+        help="Optional JSON status artifact distinguishing fetch, parse, and local failures",
+    )
     args = parser.parse_args()
+    output_path = Path(args.output)
+    status_path = Path(args.status_output) if args.status_output else None
 
     try:
-        page_count, endpoint_count = export_inventory(Path(args.output))
-    except urllib.error.URLError as exc:
-        print(f"error: failed to fetch Redis docs: {exc}", file=sys.stderr)
-        return 1
+        page_count, endpoint_count, pages_without_method_rows = export_inventory(output_path)
+    except DocsFetchError as exc:
+        write_status(
+            status_path,
+            {
+                "classification": "fetch_failure",
+                "category": exc.category,
+                "source": exc.url,
+            },
+        )
+        print(
+            f"error: official docs fetch failed ({exc.category}) for {exc.url}",
+            file=sys.stderr,
+        )
+        return EXIT_FETCH_FAILURE
+    except DocsParseError as exc:
+        write_status(
+            status_path,
+            {"classification": "parse_failure", "message": str(exc)},
+        )
+        print(f"error: official docs parse failed: {exc}", file=sys.stderr)
+        return EXIT_PARSE_FAILURE
+    except OSError as exc:
+        write_status(
+            status_path,
+            {"classification": "local_failure", "category": type(exc).__name__},
+        )
+        print(f"error: could not write inventory artifacts: {type(exc).__name__}", file=sys.stderr)
+        return EXIT_LOCAL_FAILURE
+
+    write_status(
+        status_path,
+        {
+            "classification": "success",
+            "docs_pages": page_count,
+            "inventory_rows": endpoint_count,
+            "output": str(output_path),
+            "pages_without_method_rows": pages_without_method_rows,
+        },
+    )
 
     print(f"Exported {endpoint_count} endpoints from {page_count} docs pages to {args.output}")
     return 0

--- a/scripts/summarize_live_compliance.py
+++ b/scripts/summarize_live_compliance.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python3
+"""Render a sanitized live-compliance JSON report as a Markdown summary."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+
+class ComplianceReportError(RuntimeError):
+    """A compliance report is missing required provenance or summary data."""
+
+
+SUMMARY_FIELDS = [
+    "total",
+    "pass",
+    "known_difference",
+    "version_specific",
+    "skipped",
+    "unsupported",
+    "fail",
+    "model_dropped_fields",
+    "model_failed",
+]
+
+
+def load_report(path: Path) -> dict[str, object]:
+    try:
+        report = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ComplianceReportError(
+            f"could not read compliance report: {type(exc).__name__}"
+        ) from exc
+    if not isinstance(report, dict):
+        raise ComplianceReportError("compliance report root must be an object")
+    return report
+
+
+def validate_report(
+    report: dict[str, object], expected_version: str, expected_image: str
+) -> dict[str, int]:
+    version_family = report.get("version_family")
+    if not isinstance(version_family, str) or not version_family:
+        raise ComplianceReportError("compliance report version_family must be text")
+    if report.get("server_version") != expected_version:
+        raise ComplianceReportError(
+            f"expected server version {expected_version!r}, got {report.get('server_version')!r}"
+        )
+    if report.get("image") != expected_image:
+        raise ComplianceReportError(
+            f"expected image {expected_image!r}, got {report.get('image')!r}"
+        )
+    summary = report.get("summary")
+    if not isinstance(summary, dict):
+        raise ComplianceReportError("compliance report summary must be an object")
+
+    normalized = {}
+    for field in SUMMARY_FIELDS:
+        value = summary.get(field)
+        if not isinstance(value, int) or isinstance(value, bool) or value < 0:
+            raise ComplianceReportError(f"summary field {field!r} must be a nonnegative integer")
+        normalized[field] = value
+    classified_total = sum(
+        normalized[field]
+        for field in [
+            "pass",
+            "known_difference",
+            "version_specific",
+            "skipped",
+            "unsupported",
+            "fail",
+        ]
+    )
+    if classified_total != normalized["total"]:
+        raise ComplianceReportError(
+            "compliance status counts do not add up to the reported total"
+        )
+    return normalized
+
+
+def render_report(
+    report: dict[str, object], summary: dict[str, int], profile: str
+) -> str:
+    result = "pass" if compliance_passed(summary) else "fail"
+    lines = [
+        f"# Redis Software {report['version_family']} compliance",
+        "",
+        f"**Outcome:** {result}",
+        "",
+        f"- Product version: `{report['server_version']}`",
+        f"- Container image: `{report['image']}`",
+        f"- Profile: `{profile}`",
+        f"- Inventoried operations: `{summary['total']}`",
+        f"- Pass: `{summary['pass']}`",
+        f"- Known differences: `{summary['known_difference']}`",
+        f"- Version-specific: `{summary['version_specific']}`",
+        f"- Skipped: `{summary['skipped']}`",
+        f"- Unsupported: `{summary['unsupported']}`",
+        f"- Failures: `{summary['fail']}`",
+        f"- Model dropped-field groups: `{summary['model_dropped_fields']}`",
+        f"- Model failures: `{summary['model_failed']}`",
+        "",
+        "The source report contains only status metadata, field paths, and sanitized",
+        "error classes; it does not contain response bodies or credentials.",
+        "",
+    ]
+    return "\n".join(lines)
+
+
+def compliance_passed(summary: dict[str, int]) -> bool:
+    return (
+        summary["fail"] == 0
+        and summary["model_failed"] == 0
+        and summary["model_dropped_fields"] == 0
+    )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--input", required=True, help="Sanitized compliance JSON report")
+    parser.add_argument("--output", required=True, help="Markdown summary path")
+    parser.add_argument("--expected-version", required=True)
+    parser.add_argument("--expected-image", required=True)
+    parser.add_argument("--profile", choices=["safe", "writes"], required=True)
+    args = parser.parse_args()
+
+    try:
+        report = load_report(Path(args.input))
+        summary = validate_report(report, args.expected_version, args.expected_image)
+    except ComplianceReportError as exc:
+        print(f"error: invalid live-compliance report: {exc}", file=sys.stderr)
+        return 1
+
+    output = Path(args.output)
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(render_report(report, summary, args.profile), encoding="utf-8")
+    print(f"Wrote sanitized compliance summary to {output}")
+    if not compliance_passed(summary):
+        print("error: compliance summary contains operation or model failures", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/tests/test_api_contract_automation.py
+++ b/scripts/tests/test_api_contract_automation.py
@@ -1,0 +1,400 @@
+from __future__ import annotations
+
+import csv
+import contextlib
+import io
+import json
+import ssl
+import sys
+import tempfile
+import unittest
+import urllib.error
+from pathlib import Path
+from unittest import mock
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import check_api_inventory_drift as drift
+import export_api_inventory as exporter
+import summarize_live_compliance as summary
+
+
+def write_inventory(path: Path, rows: list[dict[str, str]]) -> None:
+    with path.open("w", newline="", encoding="utf-8") as handle:
+        writer = csv.DictWriter(
+            handle, fieldnames=["page", "method", "path", "description"]
+        )
+        writer.writeheader()
+        writer.writerows({"page": "items", **row} for row in rows)
+
+
+class InventoryDriftTests(unittest.TestCase):
+    def test_comparison_is_semantic_and_deduplicated(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            expected_path = root / "expected.csv"
+            actual_path = root / "actual.csv"
+            write_inventory(
+                expected_path,
+                [
+                    {"method": "get", "path": "/v1/items/{uid}", "description": "old"},
+                    {"method": "GET", "path": "/v1/items/{id}", "description": "duplicate"},
+                    {"method": "POST", "path": "/v1/items", "description": "create"},
+                ],
+            )
+            write_inventory(
+                actual_path,
+                [
+                    {
+                        "method": "GET",
+                        "path": "/v1/items/<item_id>/?verbose=true",
+                        "description": "changed copy",
+                    },
+                    {"method": "POST", "path": "/v1/items/", "description": "new copy"},
+                ],
+            )
+
+            expected = drift.load_operations(expected_path)
+            actual = drift.load_operations(actual_path)
+
+        self.assertEqual(expected, actual)
+        self.assertEqual(drift.compare(expected, actual), ([], []))
+
+    def test_added_and_removed_operations_are_reported_separately(self) -> None:
+        expected = {
+            drift.Operation("GET", "/v1/old"),
+            drift.Operation("GET", "/v1/shared"),
+        }
+        actual = {
+            drift.Operation("POST", "/v1/new"),
+            drift.Operation("GET", "/v1/shared"),
+        }
+        added, removed = drift.compare(expected, actual)
+        report = drift.render_report(len(expected), len(actual), added, removed)
+
+        self.assertEqual(added, [drift.Operation("POST", "/v1/new")])
+        self.assertEqual(removed, [drift.Operation("GET", "/v1/old")])
+        self.assertIn("semantic drift detected", report)
+        self.assertIn("`POST /v1/new`", report)
+        self.assertIn("`GET /v1/old`", report)
+
+    def test_malformed_inventory_is_a_comparison_failure(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "bad.csv"
+            path.write_text("description\nmissing operation\n", encoding="utf-8")
+            with self.assertRaises(drift.InventoryFormatError):
+                drift.load_operations(path)
+
+    def test_cli_writes_machine_readable_semantic_drift(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            expected = root / "expected.csv"
+            actual = root / "actual.csv"
+            report = root / "report.md"
+            status = root / "status.json"
+            crawl_status = root / "crawl-status.json"
+            write_inventory(
+                expected,
+                [{"method": "GET", "path": "/v1/old", "description": "old"}],
+            )
+            write_inventory(
+                actual,
+                [{"method": "GET", "path": "/v1/new", "description": "new"}],
+            )
+            crawl_status.write_text(
+                json.dumps(
+                    {
+                        "classification": "success",
+                        "pages_without_method_rows": [],
+                    }
+                ),
+                encoding="utf-8",
+            )
+            argv = [
+                "check_api_inventory_drift.py",
+                "--expected",
+                str(expected),
+                "--actual",
+                str(actual),
+                "--crawl-status",
+                str(crawl_status),
+                "--report",
+                str(report),
+                "--status-output",
+                str(status),
+            ]
+            with (
+                mock.patch.object(sys, "argv", argv),
+                contextlib.redirect_stderr(io.StringIO()),
+            ):
+                exit_code = drift.main()
+            payload = json.loads(status.read_text(encoding="utf-8"))
+
+        self.assertEqual(exit_code, drift.EXIT_SEMANTIC_DRIFT)
+        self.assertEqual(payload["classification"], "semantic_drift")
+        self.assertEqual(payload["added"], ["GET /v1/new"])
+        self.assertEqual(payload["removed"], ["GET /v1/old"])
+
+    def test_previously_inventoried_empty_page_is_a_parser_failure(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            expected = root / "expected.csv"
+            actual = root / "actual.csv"
+            crawl_status = root / "crawl-status.json"
+            report = root / "report.md"
+            status = root / "status.json"
+            write_inventory(
+                expected,
+                [
+                    {
+                        "page": "users",
+                        "method": "GET",
+                        "path": "/v1/users",
+                        "description": "users",
+                    }
+                ],
+            )
+            write_inventory(
+                actual,
+                [
+                    {
+                        "page": "other",
+                        "method": "GET",
+                        "path": "/v1/other",
+                        "description": "other",
+                    }
+                ],
+            )
+            crawl_status.write_text(
+                json.dumps(
+                    {
+                        "classification": "success",
+                        "pages_without_method_rows": ["users", "_index"],
+                    }
+                ),
+                encoding="utf-8",
+            )
+            argv = [
+                "check_api_inventory_drift.py",
+                "--expected",
+                str(expected),
+                "--actual",
+                str(actual),
+                "--crawl-status",
+                str(crawl_status),
+                "--report",
+                str(report),
+                "--status-output",
+                str(status),
+            ]
+            with (
+                mock.patch.object(sys, "argv", argv),
+                contextlib.redirect_stderr(io.StringIO()),
+            ):
+                exit_code = drift.main()
+            payload = json.loads(status.read_text(encoding="utf-8"))
+
+        self.assertEqual(exit_code, drift.EXIT_COMPARISON_FAILURE)
+        self.assertEqual(payload["classification"], "parse_failure")
+        self.assertIn("users", payload["message"])
+
+
+class ExportFailureClassificationTests(unittest.TestCase):
+    def test_network_failure_is_not_a_parse_or_semantic_failure(self) -> None:
+        with mock.patch.object(
+            exporter.urllib.request,
+            "urlopen",
+            side_effect=urllib.error.URLError("offline"),
+        ):
+            with self.assertRaises(exporter.DocsFetchError) as context:
+                exporter.fetch_text("https://redis.io/docs/example")
+
+        self.assertEqual(context.exception.category, "network")
+        self.assertEqual(context.exception.url, "https://redis.io/docs/example")
+
+    def test_tls_failure_is_a_distinct_fetch_failure(self) -> None:
+        tls_error = ssl.SSLCertVerificationError(1, "untrusted issuer")
+        with mock.patch.object(
+            exporter.urllib.request,
+            "urlopen",
+            side_effect=urllib.error.URLError(tls_error),
+        ):
+            with self.assertRaises(exporter.DocsFetchError) as context:
+                exporter.fetch_text("https://redis.io/docs/example")
+
+        self.assertEqual(context.exception.category, "tls")
+
+    def test_empty_parsed_inventory_is_a_parser_failure(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            with (
+                mock.patch.object(
+                    exporter,
+                    "discover_request_pages",
+                    return_value=[exporter.REQUESTS_ROOT],
+                ),
+                mock.patch.object(exporter, "fetch_text", return_value="# No endpoint table"),
+            ):
+                with self.assertRaises(exporter.DocsParseError):
+                    exporter.export_inventory(Path(directory) / "inventory.csv")
+
+    def test_status_artifact_contains_only_classification_metadata(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "status.json"
+            exporter.write_status(
+                path,
+                {"classification": "fetch_failure", "category": "network"},
+            )
+            payload = json.loads(path.read_text(encoding="utf-8"))
+
+        self.assertEqual(
+            payload,
+            {"classification": "fetch_failure", "category": "network"},
+        )
+
+    def test_cli_records_parse_failure_with_distinct_exit_code(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            status = root / "status.json"
+            argv = [
+                "export_api_inventory.py",
+                "--output",
+                str(root / "inventory.csv"),
+                "--status-output",
+                str(status),
+            ]
+            with (
+                mock.patch.object(sys, "argv", argv),
+                mock.patch.object(
+                    exporter,
+                    "export_inventory",
+                    side_effect=exporter.DocsParseError("layout changed"),
+                ),
+                contextlib.redirect_stderr(io.StringIO()),
+            ):
+                exit_code = exporter.main()
+            payload = json.loads(status.read_text(encoding="utf-8"))
+
+        self.assertEqual(exit_code, exporter.EXIT_PARSE_FAILURE)
+        self.assertEqual(payload["classification"], "parse_failure")
+
+
+class ComplianceSummaryTests(unittest.TestCase):
+    def report(self) -> dict[str, object]:
+        return {
+            "server_version": "8.2.0-25",
+            "version_family": "8.2",
+            "image": "redislabs/redis:8.2.0-25.12",
+            "summary": {
+                "total": 203,
+                "pass": 85,
+                "known_difference": 3,
+                "version_specific": 5,
+                "skipped": 110,
+                "unsupported": 0,
+                "fail": 0,
+                "model_dropped_fields": 0,
+                "model_failed": 0,
+            },
+        }
+
+    def test_summary_requires_exact_image_and_product_version(self) -> None:
+        normalized = summary.validate_report(
+            self.report(),
+            "8.2.0-25",
+            "redislabs/redis:8.2.0-25.12",
+        )
+        rendered = summary.render_report(self.report(), normalized, "safe")
+
+        self.assertIn("**Outcome:** pass", rendered)
+        self.assertIn("`redislabs/redis:8.2.0-25.12`", rendered)
+        self.assertIn("Model failures: `0`", rendered)
+        self.assertTrue(summary.compliance_passed(normalized))
+
+    def test_summary_rejects_wrong_matrix_provenance(self) -> None:
+        with self.assertRaises(summary.ComplianceReportError):
+            summary.validate_report(
+                self.report(),
+                "8.0.20-68",
+                "redislabs/redis:8.2.0-25.12",
+            )
+
+    def test_summary_rejects_boolean_or_negative_counts(self) -> None:
+        report = self.report()
+        report["summary"]["fail"] = True  # type: ignore[index]
+        with self.assertRaises(summary.ComplianceReportError):
+            summary.validate_report(
+                report,
+                "8.2.0-25",
+                "redislabs/redis:8.2.0-25.12",
+            )
+
+    def test_summary_rejects_inconsistent_operation_totals(self) -> None:
+        report = self.report()
+        report["summary"]["total"] = 204  # type: ignore[index]
+        with self.assertRaises(summary.ComplianceReportError):
+            summary.validate_report(
+                report,
+                "8.2.0-25",
+                "redislabs/redis:8.2.0-25.12",
+            )
+
+    def test_summary_fails_when_model_fields_are_dropped(self) -> None:
+        normalized = summary.validate_report(
+            self.report(),
+            "8.2.0-25",
+            "redislabs/redis:8.2.0-25.12",
+        )
+        normalized["model_dropped_fields"] = 1
+        self.assertFalse(summary.compliance_passed(normalized))
+
+
+class WorkflowContractTests(unittest.TestCase):
+    def test_workflow_is_external_only_and_pins_the_support_matrix(self) -> None:
+        workflow = (
+            Path(__file__).resolve().parents[2]
+            / ".github"
+            / "workflows"
+            / "enterprise-contract.yml"
+        ).read_text(encoding="utf-8")
+
+        self.assertIn('cron: "17 6 * * 1"', workflow)
+        self.assertIn("workflow_dispatch:", workflow)
+        self.assertNotIn("pull_request:", workflow)
+        self.assertNotIn("push:", workflow)
+        for image in [
+            "redislabs/redis:8.2.0-25.12",
+            "redislabs/redis:8.0.20-68.25",
+            "redislabs/redis:7.22.2-170",
+            "redislabs/redis:7.8.6-286",
+            "redislabs/redis:7.4.6-272",
+        ]:
+            self.assertIn(image, workflow)
+
+        compose = (
+            Path(__file__).resolve().parents[2] / "docker-compose.yml"
+        ).read_text(encoding="utf-8")
+        self.assertIn(
+            "ghcr.io/redis-developer/redisctl@sha256:"
+            "2d8b5148226705ae4c057611c4adcd2c9ba08cac0c02cec1c449fc31b92a2026",
+            compose,
+        )
+        self.assertNotIn("redisctl:latest", compose)
+
+    def test_scheduled_profile_is_safe_and_writes_require_manual_dispatch(self) -> None:
+        workflow = (
+            Path(__file__).resolve().parents[2]
+            / ".github"
+            / "workflows"
+            / "enterprise-contract.yml"
+        ).read_text(encoding="utf-8")
+
+        self.assertIn(
+            "github.event_name == 'workflow_dispatch' && inputs.run_disposable_writes",
+            workflow,
+        )
+        self.assertIn("REDIS_ENTERPRISE_LIVE_WRITES=true", workflow)
+        self.assertIn("docker compose --profile init down -v", workflow)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Scope

Closes #108.

## What changed

- Added a weekly and manually dispatchable `Enterprise API contract` workflow.
- Compares fresh official-doc inventory with the reviewed inventory by normalized HTTP method/path, without treating descriptions, page order, duplicates, query strings, trailing slashes, or placeholder names as drift.
- Separately classifies fetch, page-parser, local-output, CSV-comparison, and semantic-route failures, with machine-readable and Markdown artifacts retained for 30 days.
- Runs safe live compliance against the pinned 8.2, 8.0, 7.22, 7.8, and 7.4 Redis Software images in isolated disposable stacks.
- Keeps write lifecycles behind an explicit manual-dispatch toggle and always tears down containers and volumes.
- Pins the redisctl cluster initializer to an immutable reviewed multi-architecture digest, with an explicit local override.
- Validates exact server/image provenance, operation totals, model failures, and dropped fields before publishing sanitized summaries.
- Documents cadence, ownership, response procedures, local reproduction, and inventory-refresh safety.
- Adds deterministic unit tests for the crawler, drift comparison, failure classification, report validation, and workflow safety invariants.

## Validation

- `python3 -m unittest discover -s scripts/tests -p 'test_*.py'` (25 tests)
- `python3 -m py_compile scripts/export_api_inventory.py scripts/check_api_inventory_drift.py scripts/summarize_live_compliance.py scripts/tests/test_api_contract_automation.py`
- `go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/enterprise-contract.yml`
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-features --quiet`
- `python3 scripts/audit_api_coverage.py`
- `docker compose --profile init config --images`
- Real official-doc crawl with a trusted CA bundle: 107 pages, 209 rows, 203 unique operations, no semantic route drift
- Sanitized live-summary validation against the prior 8.2 report: 203 operations and zero operation/model failures or dropped-field groups
