### PR TITLE
ci: add coverage and dependency quality gates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,19 @@ jobs:
           python3 scripts/audit_api_coverage.py
           git diff --exit-code -- docs/api-coverage-audit.csv docs/api-coverage-audit.md
 
+  audit:
+    name: Dependency policy
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Check advisories, bans, licenses, and sources
+        uses: EmbarkStudios/cargo-deny-action@v2.1.1
+        with:
+          rust-version: "1.89"
+          command: check advisories bans licenses sources
+          arguments: --all-features
+
   test:
     name: Test
     needs: check
@@ -69,6 +82,70 @@ jobs:
 
       - name: Run integration tests
         run: cargo test --test '*' --all-features
+
+  coverage:
+    name: Rust coverage
+    needs: check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust coverage tools
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: llvm-tools-preview
+
+      - name: Cache cargo
+        uses: Swatinem/rust-cache@v2
+
+      - name: Install cargo-llvm-cov
+        uses: taiki-e/install-action@v2.85.7
+        with:
+          tool: cargo-llvm-cov@0.8.7
+          fallback: none
+
+      - name: Prepare coverage artifact directory
+        run: mkdir -p target/coverage-artifacts
+
+      - name: Measure all-feature coverage
+        run: >-
+          cargo llvm-cov --all-features --json --summary-only
+          --output-path target/coverage-artifacts/coverage.json
+
+      - name: Enforce reviewed coverage floors
+        run: >-
+          python3 scripts/check_coverage.py
+          --config quality-gates.toml
+          --report target/coverage-artifacts/coverage.json
+          --summary target/coverage-artifacts/coverage-summary.md
+
+      - name: Generate LCOV report
+        run: >-
+          cargo llvm-cov report --lcov
+          --output-path target/coverage-artifacts/lcov.info
+
+      - name: Publish coverage job summary
+        run: cat target/coverage-artifacts/coverage-summary.md >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload coverage artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: rust-coverage-${{ github.run_id }}
+          path: |
+            target/coverage-artifacts/coverage.json
+            target/coverage-artifacts/coverage-summary.md
+            target/coverage-artifacts/lcov.info
+          if-no-files-found: warn
+          retention-days: 30
+
+      - name: Upload coverage to Codecov (optional reporting)
+        continue-on-error: true
+        uses: codecov/codecov-action@v5.5.5
+        with:
+          files: target/coverage-artifacts/lcov.info
+          disable_search: true
+          fail_ci_if_error: false
 
   build:
     name: Build - ${{ matrix.os }}
@@ -93,7 +170,7 @@ jobs:
   ci-status:
     name: CI Status
     runs-on: ubuntu-latest
-    needs: [check, test, build]
+    needs: [check, audit, test, coverage, build]
     if: always()
     steps:
       - name: Check CI status
@@ -104,6 +181,18 @@ jobs:
           fi
           if [[ "${{ needs.test.result }}" != "success" ]]; then
             echo "Tests failed"
+            exit 1
+          fi
+          if [[ "${{ needs.audit.result }}" != "success" ]]; then
+            echo "Dependency policy failed"
+            exit 1
+          fi
+          if [[ "${{ needs.coverage.result }}" != "success" ]]; then
+            echo "Coverage gate failed"
+            exit 1
+          fi
+          if [[ "${{ needs.build.result }}" != "success" ]]; then
+            echo "Platform build failed"
             exit 1
           fi
           echo "CI passed!"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -72,9 +72,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.100"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "assert-json-diff"

--- a/README.md
+++ b/README.md
@@ -180,6 +180,7 @@ public-doc inventory. The earlier docs-only triage remains available as
 - [Local live-validation runbook](docs/live-validation.md) — bring up a disposable Redis Enterprise cluster via Docker Compose for SDK validation against the real API.
 - [Model-fidelity evidence](docs/model-fidelity.md) — documented fields, sanitized cross-version fixtures, lossless additive-field handling, and exact request wire shapes.
 - [Enterprise API contract automation](docs/contract-automation.md) — scheduled official-doc drift detection and the disposable supported-version live matrix.
+- [Coverage and dependency quality gates](docs/quality-gates.md) — measured Rust coverage floors plus RustSec, license, ban, and source policy.
 - [Non-inventory route evidence](docs/non-inventory-route-evidence.md) — versioned live dispositions for SDK method/path pairs absent from the public-doc inventory.
 
 ## License

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,33 @@
+# Dependency policy for redis-enterprise-rs.
+#
+# Any advisory ignore, license exception, banned-crate skip, or source allowance
+# must include a narrow reason and receive explicit review.
+
+[graph]
+all-features = true
+
+[advisories]
+ignore = []
+
+[licenses]
+allow = [
+    "MIT",
+    "Apache-2.0",
+    "Apache-2.0 WITH LLVM-exception",
+    "BSD-3-Clause",
+    "ISC",
+    "Unicode-3.0",
+    "CDLA-Permissive-2.0",
+]
+confidence-threshold = 0.8
+
+[bans]
+multiple-versions = "warn"
+wildcards = "deny"
+highlight = "all"
+
+[sources]
+unknown-registry = "deny"
+unknown-git = "deny"
+allow-registry = ["https://github.com/rust-lang/crates.io-index"]
+allow-git = []

--- a/docs/quality-gates.md
+++ b/docs/quality-gates.md
@@ -1,0 +1,77 @@
+# Coverage and Dependency Quality Gates
+
+The main CI workflow enforces two local, deterministic quality gates before any
+optional reporting service is contacted.
+
+## Rust coverage
+
+The coverage job runs the complete non-ignored Rust test suite with every crate
+feature enabled. The Linux baseline measured on 2026-08-04 with
+cargo-llvm-cov 0.8.7 was reproduced exactly on macOS:
+
+| Metric | Covered | Total | Baseline | Enforced floor |
+|---|---:|---:|---:|---:|
+| Lines | 2,279 | 3,656 | 62.34% | 60.00% |
+| Functions | 576 | 953 | 60.44% | 58.00% |
+
+The reviewed source of truth is `quality-gates.toml`. The floors leave less
+than three percentage points of headroom for instrumentation changes while
+blocking a material regression. `scripts/check_coverage.py` rejects malformed
+reports, inconsistent counts, and a floor more than three points below its
+recorded baseline.
+
+To reproduce the gate locally:
+
+```bash
+rustup component add llvm-tools-preview
+cargo install cargo-llvm-cov --version 0.8.7 --locked
+mkdir -p target/coverage-artifacts
+cargo llvm-cov --all-features --json --summary-only --output-path target/coverage-artifacts/coverage.json
+python3 scripts/check_coverage.py \
+  --config quality-gates.toml \
+  --report target/coverage-artifacts/coverage.json \
+  --summary target/coverage-artifacts/coverage-summary.md
+cargo llvm-cov report --lcov --output-path target/coverage-artifacts/lcov.info
+```
+
+CI uploads the JSON, LCOV, and Markdown summary for 30 days. Codecov upload is
+explicitly non-blocking: a reporting outage cannot hide or reverse the result
+of the local floor check.
+
+Threshold changes must update the measured counts and percentages in
+`quality-gates.toml`, explain why the baseline moved, and receive explicit
+review. Raise floors as sustained coverage improves. A reduction is not a way
+to make an unrelated PR green; add tests or isolate a genuine instrumentation
+change first.
+
+Patch coverage is intentionally informational through Codecov rather than a
+required gate. Handler-heavy generated-style modules make small diffs noisy,
+and a required external patch check would couple source acceptance to a service
+outage. The deterministic repository floor remains the required regression
+gate.
+
+## Dependency, license, and source policy
+
+`deny.toml` is enforced by cargo-deny across all features. The gate fails for:
+
+- actionable RustSec advisories;
+- wildcard dependency requirements;
+- licenses outside the narrow reviewed allowlist; and
+- dependencies from unknown registries or Git repositories.
+
+Duplicate transitive versions are warnings because platform support currently
+pulls several unavoidable Windows and error-stack versions. They remain visible
+for cleanup without blocking security fixes.
+
+Run the same policy locally with:
+
+```bash
+cargo install cargo-deny --version 0.19.8 --locked
+cargo deny --all-features check advisories bans licenses sources
+```
+
+Do not ignore an advisory merely because the affected API is not currently
+called. Upgrade or remove the dependency first. If no fixed version exists and
+an exception is unavoidable, add the narrow advisory ID or package rule with a
+reason, impact analysis, owner, and removal condition in the reviewing PR.
+License, ban, or source exceptions require the same evidence.

--- a/quality-gates.toml
+++ b/quality-gates.toml
@@ -1,0 +1,15 @@
+schema = 1
+
+[coverage.baseline]
+measured_on = "2026-08-04"
+tool = "cargo-llvm-cov 0.8.7"
+line_covered = 2279
+line_count = 3656
+line_percent = 62.33588621444201
+function_covered = 576
+function_count = 953
+function_percent = 60.44071353620147
+
+[coverage.minimum]
+line_percent = 60.0
+function_percent = 58.0

--- a/scripts/check_coverage.py
+++ b/scripts/check_coverage.py
@@ -1,0 +1,235 @@
+#!/usr/bin/env python3
+"""Validate an llvm-cov JSON summary against reviewed repository thresholds."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import sys
+import tomllib
+from dataclasses import dataclass
+from pathlib import Path
+
+MAX_BASELINE_SLACK = 3.0
+EXIT_REGRESSION = 1
+EXIT_INPUT_FAILURE = 2
+
+
+class CoverageInputError(RuntimeError):
+    """Coverage configuration or report data is malformed."""
+
+
+@dataclass(frozen=True)
+class Metric:
+    covered: int
+    count: int
+    percent: float
+
+
+@dataclass(frozen=True)
+class CoveragePolicy:
+    baseline_lines: Metric
+    baseline_functions: Metric
+    minimum_lines: float
+    minimum_functions: float
+    measured_on: str
+    tool: str
+
+
+def _table(parent: object, key: str) -> dict[str, object]:
+    if not isinstance(parent, dict) or not isinstance(parent.get(key), dict):
+        raise CoverageInputError(f"missing or invalid {key!r} table")
+    return parent[key]
+
+
+def _number(table: dict[str, object], key: str) -> float:
+    value = table.get(key)
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise CoverageInputError(f"{key!r} must be numeric")
+    value = float(value)
+    if not math.isfinite(value) or value < 0:
+        raise CoverageInputError(f"{key!r} must be finite and nonnegative")
+    return value
+
+
+def _count(table: dict[str, object], key: str) -> int:
+    value = table.get(key)
+    if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+        raise CoverageInputError(f"{key!r} must be a positive integer")
+    return value
+
+
+def _covered(table: dict[str, object], key: str) -> int:
+    value = table.get(key)
+    if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+        raise CoverageInputError(f"{key!r} must be a nonnegative integer")
+    return value
+
+
+def _text(table: dict[str, object], key: str) -> str:
+    value = table.get(key)
+    if not isinstance(value, str) or not value.strip():
+        raise CoverageInputError(f"{key!r} must be non-empty text")
+    return value
+
+
+def _metric(
+    table: dict[str, object], covered_key: str, count_key: str, percent_key: str
+) -> Metric:
+    covered = _covered(table, covered_key)
+    count = _count(table, count_key)
+    percent = _number(table, percent_key)
+    if covered > count:
+        raise CoverageInputError(f"{covered_key!r} cannot exceed {count_key!r}")
+    calculated = covered / count * 100
+    if not math.isclose(calculated, percent, abs_tol=0.01):
+        raise CoverageInputError(
+            f"{percent_key!r} does not match {covered_key!r}/{count_key!r}"
+        )
+    return Metric(covered, count, percent)
+
+
+def load_policy(path: Path) -> CoveragePolicy:
+    try:
+        payload = tomllib.loads(path.read_text(encoding="utf-8"))
+    except (OSError, tomllib.TOMLDecodeError) as exc:
+        raise CoverageInputError(
+            f"could not read coverage policy: {type(exc).__name__}"
+        ) from exc
+    if payload.get("schema") != 1:
+        raise CoverageInputError("coverage policy schema must be 1")
+
+    coverage = _table(payload, "coverage")
+    baseline = _table(coverage, "baseline")
+    minimum = _table(coverage, "minimum")
+    baseline_lines = _metric(
+        baseline, "line_covered", "line_count", "line_percent"
+    )
+    baseline_functions = _metric(
+        baseline,
+        "function_covered",
+        "function_count",
+        "function_percent",
+    )
+    minimum_lines = _number(minimum, "line_percent")
+    minimum_functions = _number(minimum, "function_percent")
+
+    for name, baseline_value, minimum_value in [
+        ("line", baseline_lines.percent, minimum_lines),
+        ("function", baseline_functions.percent, minimum_functions),
+    ]:
+        if minimum_value > baseline_value:
+            raise CoverageInputError(f"{name} minimum exceeds its recorded baseline")
+        if baseline_value - minimum_value > MAX_BASELINE_SLACK:
+            raise CoverageInputError(
+                f"{name} minimum is more than {MAX_BASELINE_SLACK:.1f} points below "
+                "its recorded baseline"
+            )
+
+    return CoveragePolicy(
+        baseline_lines=baseline_lines,
+        baseline_functions=baseline_functions,
+        minimum_lines=minimum_lines,
+        minimum_functions=minimum_functions,
+        measured_on=_text(baseline, "measured_on"),
+        tool=_text(baseline, "tool"),
+    )
+
+
+def load_report(path: Path) -> tuple[Metric, Metric]:
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise CoverageInputError(
+            f"could not read llvm-cov report: {type(exc).__name__}"
+        ) from exc
+    if not isinstance(payload, dict) or payload.get("type") != "llvm.coverage.json.export":
+        raise CoverageInputError("report is not an llvm-cov JSON export")
+    data = payload.get("data")
+    if not isinstance(data, list) or len(data) != 1:
+        raise CoverageInputError("llvm-cov report must contain exactly one data set")
+    totals = _table(data[0], "totals")
+
+    def report_metric(name: str) -> Metric:
+        table = _table(totals, name)
+        covered = _covered(table, "covered")
+        count = _count(table, "count")
+        percent = _number(table, "percent")
+        if covered > count:
+            raise CoverageInputError(f"{name} covered count exceeds total")
+        calculated = covered / count * 100
+        if not math.isclose(calculated, percent, abs_tol=0.01):
+            raise CoverageInputError(f"{name} percentage does not match its counts")
+        return Metric(covered, count, percent)
+
+    return report_metric("lines"), report_metric("functions")
+
+
+def coverage_passed(
+    policy: CoveragePolicy, lines: Metric, functions: Metric
+) -> bool:
+    return (
+        lines.percent >= policy.minimum_lines
+        and functions.percent >= policy.minimum_functions
+    )
+
+
+def render_summary(
+    policy: CoveragePolicy, lines: Metric, functions: Metric
+) -> str:
+    outcome = "pass" if coverage_passed(policy, lines, functions) else "fail"
+    return "\n".join(
+        [
+            "# Rust coverage gate",
+            "",
+            f"**Outcome:** {outcome}",
+            "",
+            "| Metric | Current | Floor | Recorded baseline |",
+            "|---|---:|---:|---:|",
+            (
+                f"| Lines | {lines.percent:.2f}% ({lines.covered}/{lines.count}) | "
+                f"{policy.minimum_lines:.2f}% | {policy.baseline_lines.percent:.2f}% |"
+            ),
+            (
+                f"| Functions | {functions.percent:.2f}% "
+                f"({functions.covered}/{functions.count}) | "
+                f"{policy.minimum_functions:.2f}% | "
+                f"{policy.baseline_functions.percent:.2f}% |"
+            ),
+            "",
+            f"Baseline measured {policy.measured_on} with `{policy.tool}`.",
+            "The floor is enforced locally before any optional reporting upload.",
+            "",
+        ]
+    )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--config", required=True, help="Reviewed quality-gates TOML")
+    parser.add_argument("--report", required=True, help="llvm-cov summary JSON")
+    parser.add_argument("--summary", required=True, help="Markdown result path")
+    args = parser.parse_args()
+
+    try:
+        policy = load_policy(Path(args.config))
+        lines, functions = load_report(Path(args.report))
+    except CoverageInputError as exc:
+        print(f"error: invalid coverage input: {exc}", file=sys.stderr)
+        return EXIT_INPUT_FAILURE
+
+    summary = render_summary(policy, lines, functions)
+    output = Path(args.summary)
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(summary, encoding="utf-8")
+    print(summary)
+
+    if not coverage_passed(policy, lines, functions):
+        print("error: Rust coverage is below the reviewed floor", file=sys.stderr)
+        return EXIT_REGRESSION
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/tests/test_quality_gates.py
+++ b/scripts/tests/test_quality_gates.py
@@ -1,0 +1,147 @@
+from __future__ import annotations
+
+import contextlib
+import io
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import check_coverage as coverage
+
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def write_report(path: Path, line_percent: float, function_percent: float) -> None:
+    line_count = 1000
+    function_count = 1000
+    payload = {
+        "type": "llvm.coverage.json.export",
+        "data": [
+            {
+                "totals": {
+                    "lines": {
+                        "count": line_count,
+                        "covered": round(line_percent * 10),
+                        "percent": line_percent,
+                    },
+                    "functions": {
+                        "count": function_count,
+                        "covered": round(function_percent * 10),
+                        "percent": function_percent,
+                    },
+                }
+            }
+        ],
+    }
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+
+class CoveragePolicyTests(unittest.TestCase):
+    def test_checked_in_baseline_and_floor_are_consistent(self) -> None:
+        policy = coverage.load_policy(ROOT / "quality-gates.toml")
+
+        self.assertAlmostEqual(policy.baseline_lines.percent, 62.33588621444201)
+        self.assertAlmostEqual(policy.baseline_functions.percent, 60.44071353620147)
+        self.assertEqual(policy.minimum_lines, 60.0)
+        self.assertEqual(policy.minimum_functions, 58.0)
+
+    def test_current_style_report_passes_and_renders_counts(self) -> None:
+        policy = coverage.load_policy(ROOT / "quality-gates.toml")
+        with tempfile.TemporaryDirectory() as directory:
+            report = Path(directory) / "coverage.json"
+            write_report(report, 62.3, 60.4)
+            lines, functions = coverage.load_report(report)
+            summary = coverage.render_summary(policy, lines, functions)
+
+        self.assertTrue(coverage.coverage_passed(policy, lines, functions))
+        self.assertIn("**Outcome:** pass", summary)
+        self.assertIn("623/1000", summary)
+
+    def test_material_regression_fails_the_cli_after_writing_summary(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            report = root / "coverage.json"
+            summary = root / "summary.md"
+            write_report(report, 59.9, 57.9)
+            argv = [
+                "check_coverage.py",
+                "--config",
+                str(ROOT / "quality-gates.toml"),
+                "--report",
+                str(report),
+                "--summary",
+                str(summary),
+            ]
+            with (
+                mock.patch.object(sys, "argv", argv),
+                contextlib.redirect_stdout(io.StringIO()),
+                contextlib.redirect_stderr(io.StringIO()),
+            ):
+                exit_code = coverage.main()
+            rendered = summary.read_text(encoding="utf-8")
+
+        self.assertEqual(exit_code, coverage.EXIT_REGRESSION)
+        self.assertIn("**Outcome:** fail", rendered)
+
+    def test_non_llvm_report_is_an_input_failure(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            report = Path(directory) / "coverage.json"
+            report.write_text("{}", encoding="utf-8")
+            with self.assertRaises(coverage.CoverageInputError):
+                coverage.load_report(report)
+
+    def test_zero_coverage_is_a_regression_not_malformed_input(self) -> None:
+        policy = coverage.load_policy(ROOT / "quality-gates.toml")
+        with tempfile.TemporaryDirectory() as directory:
+            report = Path(directory) / "coverage.json"
+            write_report(report, 0.0, 0.0)
+            lines, functions = coverage.load_report(report)
+
+        self.assertFalse(coverage.coverage_passed(policy, lines, functions))
+
+    def test_floor_cannot_drift_far_below_recorded_baseline(self) -> None:
+        source = (ROOT / "quality-gates.toml").read_text(encoding="utf-8")
+        with tempfile.TemporaryDirectory() as directory:
+            config = Path(directory) / "quality-gates.toml"
+            config.write_text(
+                source.replace("line_percent = 60.0", "line_percent = 50.0"),
+                encoding="utf-8",
+            )
+            with self.assertRaises(coverage.CoverageInputError):
+                coverage.load_policy(config)
+
+
+class DependencyPolicyTests(unittest.TestCase):
+    def test_security_policy_has_no_unreviewed_ignores_or_sources(self) -> None:
+        import tomllib
+
+        policy = tomllib.loads((ROOT / "deny.toml").read_text(encoding="utf-8"))
+
+        self.assertEqual(policy["advisories"]["ignore"], [])
+        self.assertEqual(policy["bans"]["wildcards"], "deny")
+        self.assertEqual(policy["sources"]["unknown-registry"], "deny")
+        self.assertEqual(policy["sources"]["unknown-git"], "deny")
+        self.assertEqual(policy["sources"]["allow-git"], [])
+
+    def test_ci_requires_local_gates_and_isolates_optional_reporting(self) -> None:
+        workflow = (ROOT / ".github" / "workflows" / "ci.yml").read_text(
+            encoding="utf-8"
+        )
+
+        self.assertIn("EmbarkStudios/cargo-deny-action@v2.1.1", workflow)
+        self.assertIn("taiki-e/install-action@v2.85.7", workflow)
+        self.assertIn("cargo-llvm-cov@0.8.7", workflow)
+        self.assertIn("python3 scripts/check_coverage.py", workflow)
+        self.assertIn("codecov/codecov-action@v5.5.5", workflow)
+        self.assertIn("continue-on-error: true", workflow)
+        self.assertIn("needs: [check, audit, test, coverage, build]", workflow)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Scope

Closes #109.

## What changed

- Added a required cargo-deny job covering RustSec advisories, dependency bans, licenses, and sources across all features.
- Uses a narrow observed license allowlist, denies wildcard requirements and unknown registries/Git sources, and carries no advisory ignores.
- Fixed the real `RUSTSEC-2026-0190` advisory surfaced by the new gate by updating locked `anyhow` from 1.0.100 to 1.0.103.
- Added an all-feature cargo-llvm-cov job with JSON, LCOV, Markdown summaries, and 30-day GitHub artifacts.
- Recorded the measured baseline at 62.34% lines (2,279/3,656) and 60.44% functions (576/953), reproduced exactly on Linux and macOS.
- Enforces modest floors of 60% lines and 58% functions with a local validator that rejects malformed/inconsistent reports and thresholds more than three points below the recorded baseline.
- Keeps Codecov patch/trend reporting optional and non-blocking; the deterministic local floor is required before upload.
- Added tests that protect advisory/source policy, coverage input validation, regression behavior, threshold slack, workflow wiring, and reporting isolation.
- Updated the aggregate CI status gate to require dependency policy, coverage, and platform builds; the previous script did not explicitly reject a failed build matrix.
- Documented exact local reproduction, exception review requirements, baseline/floor updates, and why patch coverage remains informational.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-features --quiet`
- `cargo package --allow-dirty`
- `cargo deny --all-features check advisories bans licenses sources`
- `cargo llvm-cov --all-features --json --summary-only --output-path target/coverage-artifacts/coverage.json`
- `python3 scripts/check_coverage.py --config quality-gates.toml --report target/coverage-artifacts/coverage.json --summary target/coverage-artifacts/coverage-summary.md`
- `cargo llvm-cov report --lcov --output-path target/coverage-artifacts/lcov.info`
- Linux container reproduction with Rust 1.96.1 and cargo-llvm-cov 0.8.7: exact baseline match
- `python3 -m unittest discover -s scripts/tests -p 'test_*.py'` (33 tests)
- `python3 scripts/audit_api_coverage.py`
- `go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/ci.yml`
