### PR TITLE
fix: harden supported-version contract matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
     name: Check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
@@ -55,7 +55,7 @@ jobs:
     name: Dependency policy
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Check advisories, bans, licenses, and sources
         uses: EmbarkStudios/cargo-deny-action@v2.1.1
@@ -69,7 +69,7 @@ jobs:
     needs: check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
@@ -88,7 +88,7 @@ jobs:
     needs: check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Install Rust coverage tools
         uses: dtolnay/rust-toolchain@stable
@@ -129,7 +129,7 @@ jobs:
 
       - name: Upload coverage artifacts
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: rust-coverage-${{ github.run_id }}
           path: |
@@ -156,7 +156,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/enterprise-contract.yml
+++ b/.github/workflows/enterprise-contract.yml
@@ -35,7 +35,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Prepare artifact directory
         run: mkdir -p target/contract-artifacts
@@ -75,7 +75,7 @@ jobs:
 
       - name: Upload docs contract artifacts
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: official-docs-contract-${{ github.run_id }}
           path: target/contract-artifacts/
@@ -100,18 +100,23 @@ jobs:
           - family: "8.2"
             image: redislabs/redis:8.2.0-25.12
             expected_version: 8.2.0-25
+            database_version: ""
           - family: "8.0"
             image: redislabs/redis:8.0.20-68.25
             expected_version: 8.0.20-68
+            database_version: ""
           - family: "7.22"
             image: redislabs/redis:7.22.2-170
             expected_version: 7.22.2-170
+            database_version: ""
           - family: "7.8"
             image: redislabs/redis:7.8.6-286
             expected_version: 7.8.6-286
+            database_version: ""
           - family: "7.4"
             image: redislabs/redis:7.4.6-272
             expected_version: 7.4.6-272
+            database_version: "7.2"
     env:
       REDIS_ENTERPRISE_IMAGE: ${{ matrix.image }}
       REDIS_ENTERPRISE_URL: https://localhost:9443
@@ -119,9 +124,10 @@ jobs:
       REDIS_ENTERPRISE_PASSWORD: Redis123!
       REDIS_ENTERPRISE_INSECURE: "true"
       REDIS_ENTERPRISE_EXPECTED_VERSION: ${{ matrix.expected_version }}
+      REDIS_ENTERPRISE_DATABASE_VERSION: ${{ matrix.database_version }}
       COMPLIANCE_PROFILE: ${{ github.event_name == 'workflow_dispatch' && inputs.run_disposable_writes && 'writes' || 'safe' }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
@@ -150,22 +156,40 @@ jobs:
 
       - name: Render sanitized compliance summary
         id: summarize
-        if: always() && steps.compliance.outcome == 'success'
-        run: >-
-          python3 scripts/summarize_live_compliance.py
-          --input "target/contract-artifacts/enterprise-compliance-${{ matrix.family }}-${COMPLIANCE_PROFILE}.json"
-          --output "target/contract-artifacts/enterprise-compliance-${{ matrix.family }}-${COMPLIANCE_PROFILE}.md"
-          --expected-version "${{ matrix.expected_version }}"
-          --expected-image "${{ matrix.image }}"
-          --profile "$COMPLIANCE_PROFILE"
+        if: always()
+        continue-on-error: true
+        run: |
+          input="target/contract-artifacts/enterprise-compliance-${{ matrix.family }}-${COMPLIANCE_PROFILE}.json"
+          output="target/contract-artifacts/enterprise-compliance-${{ matrix.family }}-${COMPLIANCE_PROFILE}.md"
+          mkdir -p target/contract-artifacts
+          if [[ -f "$input" ]]; then
+            python3 scripts/summarize_live_compliance.py \
+              --input "$input" \
+              --output "$output" \
+              --expected-version "${{ matrix.expected_version }}" \
+              --expected-image "${{ matrix.image }}" \
+              --profile "$COMPLIANCE_PROFILE" \
+              --test-outcome "${{ steps.compliance.outcome }}"
+          else
+            printf '# Redis Software %s compliance\n\n**Outcome:** fail\n\nThe compliance test did not produce a sanitized report.\n' \
+              '${{ matrix.family }}' > "$output"
+            exit 1
+          fi
 
       - name: Publish compliance job summary
-        if: always() && steps.summarize.outcome == 'success'
-        run: cat "target/contract-artifacts/enterprise-compliance-${{ matrix.family }}-${COMPLIANCE_PROFILE}.md" >> "$GITHUB_STEP_SUMMARY"
+        if: always()
+        run: |
+          summary="target/contract-artifacts/enterprise-compliance-${{ matrix.family }}-${COMPLIANCE_PROFILE}.md"
+          if [[ -f "$summary" ]]; then
+            cat "$summary" >> "$GITHUB_STEP_SUMMARY"
+          else
+            printf '## Redis Software %s compliance\n\nA sanitized summary could not be rendered.\n' \
+              '${{ matrix.family }}' >> "$GITHUB_STEP_SUMMARY"
+          fi
 
       - name: Upload sanitized compliance artifacts
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: enterprise-compliance-${{ matrix.family }}-${{ env.COMPLIANCE_PROFILE }}-${{ github.run_id }}
           path: target/contract-artifacts/
@@ -175,3 +199,9 @@ jobs:
       - name: Remove disposable cluster and volumes
         if: always()
         run: docker compose --profile init down -v
+
+      - name: Enforce live contract result
+        if: always()
+        run: |
+          test "${{ steps.compliance.outcome }}" = "success"
+          test "${{ steps.summarize.outcome }}" = "success"

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -22,10 +22,10 @@ jobs:
     name: Unit tests (Python bindings)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v7
         with:
           python-version: "3.12"
 
@@ -60,10 +60,10 @@ jobs:
           - os: windows-latest
             build-args: --release --out dist
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v7
         with:
           python-version: "3.12"
 
@@ -82,7 +82,7 @@ jobs:
           manylinux: auto
 
       - name: Upload wheels
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: wheels-${{ matrix.os }}
           path: python/dist
@@ -91,10 +91,10 @@ jobs:
     name: Build source distribution
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v7
         with:
           python-version: "3.12"
 
@@ -109,7 +109,7 @@ jobs:
           args: --out dist
 
       - name: Upload sdist
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: wheels-sdist
           path: python/dist
@@ -124,12 +124,12 @@ jobs:
         python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
     steps:
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v7
         with:
           python-version: ${{ matrix.python-version }}
 
       - name: Download Linux wheels
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: wheels-ubuntu-latest
           path: dist
@@ -150,7 +150,7 @@ jobs:
       id-token: write
     steps:
       - name: Download artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           pattern: wheels-*
           path: dist

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -21,7 +21,7 @@ jobs:
     environment: crates-io
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
           token: ${{ secrets.RELEASE_TOKEN }}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,18 +41,50 @@ services:
         condition: service_healthy
     environment:
       REDIS_ENTERPRISE_URL: "https://redis-enterprise:9443"
+      REDIS_ENTERPRISE_USER: "admin@redis.local"
+      REDIS_ENTERPRISE_PASSWORD: "Redis123!"
       REDIS_ENTERPRISE_INSECURE: "true"
+      REDIS_ENTERPRISE_DATABASE_VERSION: "${REDIS_ENTERPRISE_DATABASE_VERSION:-}"
+    entrypoint: ["/bin/sh", "-ec"]
     command:
-      [
-        "enterprise",
-        "workflow",
-        "init-cluster",
-        "--name",
-        "test-cluster",
-        "--username",
-        "admin@redis.local",
-        "--password",
-        "Redis123!",
-      ]
+      - |
+        redisctl enterprise workflow init-cluster \
+          --name test-cluster \
+          --username admin@redis.local \
+          --password 'Redis123!' \
+          --skip-database
+
+        database_data='{"name":"default-db","memory_size":1073741824,"type":"redis","replication":false}'
+        if [ -n "$$REDIS_ENTERPRISE_DATABASE_VERSION" ]; then
+          database_data=$$(printf \
+            '{"name":"default-db","memory_size":1073741824,"type":"redis","replication":false,"redis_version":"%s"}' \
+            "$$REDIS_ENTERPRISE_DATABASE_VERSION")
+        fi
+        create_attempt=0
+        until redisctl enterprise database create --data "$$database_data" --output json > /dev/null; do
+          create_attempt=$$((create_attempt + 1))
+          if [ "$$create_attempt" -ge 60 ]; then
+            echo "Required disposable database could not be created" >&2
+            exit 1
+          fi
+          echo "Database create is not ready; retrying in 5 seconds"
+          sleep 5
+        done
+
+        attempt=0
+        while [ "$$attempt" -lt 120 ]; do
+          databases=$$(redisctl enterprise database list --output json)
+          shards=$$(redisctl enterprise shard list --output json)
+          if echo "$$databases" | grep -Eq '"status"[[:space:]]*:[[:space:]]*"active"' \
+            && echo "$$shards" | grep -Eq '"uid"[[:space:]]*:'; then
+            echo "Disposable database and shard are ready"
+            exit 0
+          fi
+          attempt=$$((attempt + 1))
+          sleep 5
+        done
+
+        echo "Required disposable database and shard did not become ready" >&2
+        exit 1
     profiles:
       - init

--- a/docs/contract-automation.md
+++ b/docs/contract-automation.md
@@ -64,8 +64,11 @@ in the [version support policy](./version-support.md): 8.2, 8.0, 7.22, 7.8,
 and 7.4. Each matrix runner:
 
 - pulls the exact Redis Software image;
-- initializes a local cluster and default database with the immutable redisctl
-  image digest checked into `docker-compose.yml`;
+- initializes a local cluster with the immutable redisctl image digest checked
+  into `docker-compose.yml`, then strictly creates and waits for the required
+  default database and shard;
+- supplies Redis database version `7.2` for the 7.4 family, whose early
+  post-bootstrap API rejects a versionless create until policy state settles;
 - runs the versioned compliance baseline;
 - verifies that the report's product version and image match the matrix;
 - uploads sanitized JSON and Markdown summaries; and
@@ -81,6 +84,9 @@ guard and safety review.
 The report contains operation status, model field paths, exact image/version
 provenance, and sanitized error classes. It never stores response bodies,
 credentials, license values, resource identifiers, or customer data.
+Typed model fidelity is measured by deserializing and reserializing the exact
+raw payload being evaluated, so differences between two successive API reads
+cannot produce false dropped-field drift.
 
 ### Responding to live failures
 

--- a/docs/live-validation.md
+++ b/docs/live-validation.md
@@ -35,10 +35,15 @@ The compose file defaults to:
 - `REDIS_ENTERPRISE_API_PORT=9443`
 - `REDIS_ENTERPRISE_UI_PORT=8443`
 - `REDIS_ENTERPRISE_DB_PORT=12000`
+- `REDIS_ENTERPRISE_DATABASE_VERSION` unset (use the server default)
 
 The initializer also defaults to an immutable reviewed redisctl image digest.
 Set `REDISCTL_IMAGE` only when intentionally validating a newer initializer;
-scheduled contract runs use the checked-in digest.
+scheduled contract runs use the checked-in digest. The Compose fixture treats
+the database and its first shard as required state: it initializes the cluster,
+creates the database with retries while the cluster policy settles, waits for
+both resources to become active and discoverable, and exits nonzero if any of
+those steps fail.
 
 You can override the host ports to avoid collisions with an existing local
 cluster:
@@ -85,9 +90,15 @@ pin before every Compose command for that cluster lifecycle:
 
 ```bash
 export REDIS_ENTERPRISE_IMAGE="redislabs/redis:7.4.6-272"
+export REDIS_ENTERPRISE_DATABASE_VERSION="7.2"
 docker compose up -d redis-enterprise
 docker compose --profile init up init
 ```
+
+Redis Software 7.4 advertises a 7.2.x database engine but requires the
+major/minor request value `7.2` during this early post-bootstrap window. The
+hosted matrix pins that value explicitly; later families leave the variable
+unset and use their reviewed server default.
 
 Each matrix entry must use a fresh named volume or run after `docker compose
 down -v`; cluster state is not portable between server versions. Docker images

--- a/scripts/summarize_live_compliance.py
+++ b/scripts/summarize_live_compliance.py
@@ -81,14 +81,18 @@ def validate_report(
 
 
 def render_report(
-    report: dict[str, object], summary: dict[str, int], profile: str
+    report: dict[str, object],
+    summary: dict[str, int],
+    profile: str,
+    test_outcome: str = "success",
 ) -> str:
-    result = "pass" if compliance_passed(summary) else "fail"
+    result = "pass" if compliance_passed(summary, test_outcome) else "fail"
     lines = [
         f"# Redis Software {report['version_family']} compliance",
         "",
         f"**Outcome:** {result}",
         "",
+        f"- Compliance test: `{test_outcome}`",
         f"- Product version: `{report['server_version']}`",
         f"- Container image: `{report['image']}`",
         f"- Profile: `{profile}`",
@@ -109,9 +113,12 @@ def render_report(
     return "\n".join(lines)
 
 
-def compliance_passed(summary: dict[str, int]) -> bool:
+def compliance_passed(
+    summary: dict[str, int], test_outcome: str = "success"
+) -> bool:
     return (
-        summary["fail"] == 0
+        test_outcome == "success"
+        and summary["fail"] == 0
         and summary["model_failed"] == 0
         and summary["model_dropped_fields"] == 0
     )
@@ -124,6 +131,12 @@ def main() -> int:
     parser.add_argument("--expected-version", required=True)
     parser.add_argument("--expected-image", required=True)
     parser.add_argument("--profile", choices=["safe", "writes"], required=True)
+    parser.add_argument(
+        "--test-outcome",
+        choices=["success", "failure", "cancelled", "skipped"],
+        default="success",
+        help="GitHub Actions outcome of the compliance test step",
+    )
     args = parser.parse_args()
 
     try:
@@ -135,9 +148,12 @@ def main() -> int:
 
     output = Path(args.output)
     output.parent.mkdir(parents=True, exist_ok=True)
-    output.write_text(render_report(report, summary, args.profile), encoding="utf-8")
+    output.write_text(
+        render_report(report, summary, args.profile, args.test_outcome),
+        encoding="utf-8",
+    )
     print(f"Wrote sanitized compliance summary to {output}")
-    if not compliance_passed(summary):
+    if not compliance_passed(summary, args.test_outcome):
         print("error: compliance summary contains operation or model failures", file=sys.stderr)
         return 1
     return 0

--- a/scripts/tests/test_api_contract_automation.py
+++ b/scripts/tests/test_api_contract_automation.py
@@ -306,6 +306,7 @@ class ComplianceSummaryTests(unittest.TestCase):
         rendered = summary.render_report(self.report(), normalized, "safe")
 
         self.assertIn("**Outcome:** pass", rendered)
+        self.assertIn("Compliance test: `success`", rendered)
         self.assertIn("`redislabs/redis:8.2.0-25.12`", rendered)
         self.assertIn("Model failures: `0`", rendered)
         self.assertTrue(summary.compliance_passed(normalized))
@@ -347,6 +348,20 @@ class ComplianceSummaryTests(unittest.TestCase):
         normalized["model_dropped_fields"] = 1
         self.assertFalse(summary.compliance_passed(normalized))
 
+    def test_summary_fails_when_test_assertion_failed(self) -> None:
+        normalized = summary.validate_report(
+            self.report(),
+            "8.2.0-25",
+            "redislabs/redis:8.2.0-25.12",
+        )
+        rendered = summary.render_report(
+            self.report(), normalized, "safe", test_outcome="failure"
+        )
+
+        self.assertIn("**Outcome:** fail", rendered)
+        self.assertIn("Compliance test: `failure`", rendered)
+        self.assertFalse(summary.compliance_passed(normalized, "failure"))
+
 
 class WorkflowContractTests(unittest.TestCase):
     def test_workflow_is_external_only_and_pins_the_support_matrix(self) -> None:
@@ -378,7 +393,32 @@ class WorkflowContractTests(unittest.TestCase):
             "2d8b5148226705ae4c057611c4adcd2c9ba08cac0c02cec1c449fc31b92a2026",
             compose,
         )
+        self.assertIn('database_version: "7.2"', workflow)
+        self.assertIn("--skip-database", compose)
+        self.assertIn("Required disposable database could not be created", compose)
+        self.assertIn("Required disposable database and shard did not become ready", compose)
         self.assertNotIn("redisctl:latest", compose)
+
+    def test_workflows_use_node_24_backed_official_actions(self) -> None:
+        workflow_root = Path(__file__).resolve().parents[2] / ".github" / "workflows"
+        workflow_text = "\n".join(
+            path.read_text(encoding="utf-8") for path in workflow_root.glob("*.yml")
+        )
+
+        for current_action in [
+            "actions/checkout@v7",
+            "actions/setup-python@v7",
+            "actions/upload-artifact@v7",
+            "actions/download-artifact@v8",
+        ]:
+            self.assertIn(current_action, workflow_text)
+        for retired_action in [
+            "actions/checkout@v4",
+            "actions/setup-python@v5",
+            "actions/upload-artifact@v4",
+            "actions/download-artifact@v4",
+        ]:
+            self.assertNotIn(retired_action, workflow_text)
 
     def test_scheduled_profile_is_safe_and_writes_require_manual_dispatch(self) -> None:
         workflow = (

--- a/tests/live_compliance.rs
+++ b/tests/live_compliance.rs
@@ -17,9 +17,12 @@ use std::path::{Path, PathBuf};
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use chrono::{SecondsFormat, Utc};
-use redis_enterprise::{CreateUserRequest, EnterpriseClient, RestError, UpdateUserRequest};
+use redis_enterprise::{
+    ClusterInfo, Crdb, CreateUserRequest, Database, EnterpriseClient, License, MetricsConfig,
+    Module, Node, Proxy, RestError, Role, Shard, UpdateUserRequest, User,
+};
 use regex::Regex;
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize, de::DeserializeOwned};
 use serde_json::{Value, json};
 use tokio::time::{Duration, sleep};
 
@@ -500,54 +503,111 @@ fn collect_dropped_paths(raw: &Value, typed: &Value, path: &str, output: &mut Ve
     }
 }
 
-fn compare_model(
-    model: &str,
-    raw: Result<Value, RestError>,
-    typed: Result<Value, RestError>,
-) -> ModelComparison {
-    match (raw, typed) {
-        (Ok(raw), Ok(typed)) => {
-            let mut dropped_paths = Vec::new();
-            collect_dropped_paths(&raw, &typed, "", &mut dropped_paths);
-            dropped_paths.sort();
-            dropped_paths.dedup();
-            let status = if dropped_paths.is_empty() {
-                ModelStatus::Pass
-            } else {
-                ModelStatus::DroppedFields
-            };
-            let reason = if dropped_paths.is_empty() {
-                "raw JSON round-tripped through the typed model without dropped fields".to_string()
-            } else {
-                format!(
-                    "typed round-trip dropped {} JSON paths (capped at 200)",
-                    dropped_paths.len()
-                )
-            };
-            ModelComparison {
-                model: model.to_string(),
-                status,
-                dropped_paths,
-                reason,
-            }
-        }
-        (Err(error), _) => ModelComparison {
-            model: model.to_string(),
-            status: ModelStatus::Skipped,
-            dropped_paths: Vec::new(),
-            reason: format!("raw probe unavailable: {}", sanitized_error(&error)),
-        },
-        (_, Err(error)) => ModelComparison {
-            model: model.to_string(),
-            status: ModelStatus::Failed,
-            dropped_paths: Vec::new(),
-            reason: format!("typed deserialization failed: {}", sanitized_error(&error)),
-        },
+fn compare_model_values(model: &str, raw: Value, typed: Value) -> ModelComparison {
+    let mut dropped_paths = Vec::new();
+    collect_dropped_paths(&raw, &typed, "", &mut dropped_paths);
+    dropped_paths.sort();
+    dropped_paths.dedup();
+    let status = if dropped_paths.is_empty() {
+        ModelStatus::Pass
+    } else {
+        ModelStatus::DroppedFields
+    };
+    let reason = if dropped_paths.is_empty() {
+        "raw JSON round-tripped through the typed model without dropped fields".to_string()
+    } else {
+        format!(
+            "typed round-trip dropped {} JSON paths (capped at 200)",
+            dropped_paths.len()
+        )
+    };
+    ModelComparison {
+        model: model.to_string(),
+        status,
+        dropped_paths,
+        reason,
     }
 }
 
-fn to_json<T: Serialize>(result: Result<T, RestError>) -> Result<Value, RestError> {
-    result.and_then(|value| serde_json::to_value(value).map_err(Into::into))
+fn model_failure(model: &str, reason: &str) -> ModelComparison {
+    ModelComparison {
+        model: model.to_string(),
+        status: ModelStatus::Failed,
+        dropped_paths: Vec::new(),
+        reason: reason.to_string(),
+    }
+}
+
+fn compare_raw_model<T>(model: &str, raw: Result<Value, RestError>) -> ModelComparison
+where
+    T: DeserializeOwned + Serialize,
+{
+    let raw = match raw {
+        Ok(raw) => raw,
+        Err(error) => {
+            return ModelComparison {
+                model: model.to_string(),
+                status: ModelStatus::Skipped,
+                dropped_paths: Vec::new(),
+                reason: format!("raw probe unavailable: {}", sanitized_error(&error)),
+            };
+        }
+    };
+    let typed = match serde_json::from_value::<T>(raw.clone()) {
+        Ok(typed) => typed,
+        Err(_) => {
+            return model_failure(
+                model,
+                "typed deserialization failed for the observed JSON shape",
+            );
+        }
+    };
+    let typed = match serde_json::to_value(typed) {
+        Ok(typed) => typed,
+        Err(_) => return model_failure(model, "typed serialization failed for the observed model"),
+    };
+    compare_model_values(model, raw, typed)
+}
+
+fn compare_raw_wrapped_vec_model<T>(
+    model: &str,
+    raw: Result<Value, RestError>,
+    field: &str,
+) -> ModelComparison
+where
+    T: DeserializeOwned + Serialize,
+{
+    let raw = match raw {
+        Ok(raw) => raw,
+        Err(error) => {
+            return ModelComparison {
+                model: model.to_string(),
+                status: ModelStatus::Skipped,
+                dropped_paths: Vec::new(),
+                reason: format!("raw probe unavailable: {}", sanitized_error(&error)),
+            };
+        }
+    };
+    let Some(items) = raw.get(field).cloned() else {
+        return model_failure(
+            model,
+            "typed deserialization failed: response wrapper is missing",
+        );
+    };
+    let typed = match serde_json::from_value::<Vec<T>>(items) {
+        Ok(typed) => typed,
+        Err(_) => {
+            return model_failure(
+                model,
+                "typed deserialization failed for the observed wrapped JSON shape",
+            );
+        }
+    };
+    let typed = match serde_json::to_value(typed) {
+        Ok(typed) => json!({ field: typed }),
+        Err(_) => return model_failure(model, "typed serialization failed for the observed model"),
+    };
+    compare_model_values(model, raw, typed)
 }
 
 async fn attach_model_comparisons(
@@ -555,38 +615,32 @@ async fn attach_model_comparisons(
     reports: &mut BTreeMap<String, OperationReport>,
 ) {
     macro_rules! attach {
-        ($path:literal, $model:literal, $typed:expr) => {{
+        ($path:literal, $model:literal, $type:ty) => {{
             let raw = client.get_raw($path).await;
-            let typed = to_json($typed.await);
             if let Some(report) = reports.get_mut(concat!("GET ", $path)) {
-                report.model = Some(compare_model($model, raw, typed));
+                report.model = Some(compare_raw_model::<$type>($model, raw));
             }
         }};
     }
 
-    attach!("/v1/cluster", "ClusterInfo", client.cluster().info());
-    attach!("/v1/nodes", "Vec<Node>", client.nodes().list());
-    attach!("/v1/bdbs", "Vec<DatabaseInfo>", client.databases().list());
-    attach!("/v1/users", "Vec<User>", client.users().list());
-    attach!("/v1/roles", "Vec<Role>", client.roles().list());
-    attach!("/v1/modules", "Vec<Module>", client.modules().list());
-    attach!("/v1/shards", "Vec<Shard>", client.shards().list());
-    attach!("/v1/proxies", "Vec<Proxy>", client.proxies().list());
-    attach!("/v1/license", "License", client.license().get());
-    attach!(
-        "/v1/metrics_config",
-        "MetricsConfig",
-        client.metrics_config().get()
-    );
+    attach!("/v1/cluster", "ClusterInfo", ClusterInfo);
+    attach!("/v1/nodes", "Vec<Node>", Vec<Node>);
+    attach!("/v1/bdbs", "Vec<DatabaseInfo>", Vec<Database>);
+    attach!("/v1/users", "Vec<User>", Vec<User>);
+    attach!("/v1/roles", "Vec<Role>", Vec<Role>);
+    attach!("/v1/modules", "Vec<Module>", Vec<Module>);
+    attach!("/v1/shards", "Vec<Shard>", Vec<Shard>);
+    attach!("/v1/proxies", "Vec<Proxy>", Vec<Proxy>);
+    attach!("/v1/license", "License", License);
+    attach!("/v1/metrics_config", "MetricsConfig", MetricsConfig);
 
     let raw = client.get_raw("/v1/crdbs").await;
-    let typed = client
-        .crdb()
-        .list()
-        .await
-        .and_then(|crdbs| serde_json::to_value(json!({ "crdbs": crdbs })).map_err(Into::into));
     if let Some(report) = reports.get_mut("GET /v1/crdbs") {
-        report.model = Some(compare_model("Vec<Crdb>", raw, typed));
+        report.model = Some(compare_raw_wrapped_vec_model::<Crdb>(
+            "Vec<Crdb>",
+            raw,
+            "crdbs",
+        ));
     }
 }
 
@@ -1034,7 +1088,7 @@ fn dropped_path_comparison_records_names_not_values() {
         {"uid": 1, "nested": {"kept": true}},
         {"uid": 2, "nested": {"kept": true}}
     ]);
-    let comparison = compare_model("Example", Ok(raw), Ok(typed));
+    let comparison = compare_model_values("Example", raw, typed);
     assert_eq!(comparison.status, ModelStatus::DroppedFields);
     assert_eq!(comparison.dropped_paths, ["/*/nested/dropped"]);
     assert!(!comparison.reason.contains("secret-one"));
@@ -1050,9 +1104,50 @@ fn dropped_path_comparison_ignores_omitted_nulls_but_not_values() {
     });
     let typed = json!({});
 
-    let comparison = compare_model("Example", Ok(raw), Ok(typed));
+    let comparison = compare_model_values("Example", raw, typed);
     assert_eq!(comparison.status, ModelStatus::DroppedFields);
     assert_eq!(comparison.dropped_paths, ["/unknown_value"]);
+}
+
+#[test]
+fn model_fidelity_uses_one_observed_payload() {
+    #[derive(Debug, Serialize, Deserialize)]
+    struct PreservingModel {
+        stable: bool,
+        #[serde(flatten)]
+        additional_fields: BTreeMap<String, Value>,
+    }
+
+    let observed = json!({
+        "stable": true,
+        "grpc_gossip": true,
+        "grpc_gossip_only": true,
+        "grpc_info_provider": false
+    });
+    let later_response = json!({"stable": true});
+
+    let cross_request = compare_model_values("PreservingModel", observed.clone(), later_response);
+    assert_eq!(cross_request.status, ModelStatus::DroppedFields);
+
+    let same_payload = compare_raw_model::<PreservingModel>("PreservingModel", Ok(observed));
+    assert_eq!(same_payload.status, ModelStatus::Pass);
+    assert!(same_payload.dropped_paths.is_empty());
+}
+
+#[test]
+fn model_fidelity_classifies_deserialization_failures_without_values() {
+    #[derive(Debug, Serialize, Deserialize)]
+    struct NumericModel {
+        count: u32,
+    }
+
+    let comparison = compare_raw_model::<NumericModel>(
+        "NumericModel",
+        Ok(json!({"count": "sensitive-server-value"})),
+    );
+    assert_eq!(comparison.status, ModelStatus::Failed);
+    assert!(comparison.reason.contains("deserialization failed"));
+    assert!(!comparison.reason.contains("sensitive-server-value"));
 }
 
 #[test]


### PR DESCRIPTION
## Scope

- Closes #124: make model-fidelity comparison deterministic by deserializing and reserializing one observed raw payload.
- Closes #125: migrate repository workflows from deprecated Node 20-backed official action majors to verified Node 24-backed releases.
- Closes #126: make the supported-version fixture bootstrap strict, provision Redis Software 7.4 with a compatible database version, wait for required resources, review the 7.4 baseline, and publish sanitized failure summaries.

## Changes

1. Refactors live model comparison so raw and typed representations come from the same response, with regression coverage for cross-request differences and sanitized deserialization failures.
2. Splits cluster initialization from database provisioning in the disposable Compose fixture, retries the real early 7.4 `invalid_version` window, suppresses secret-bearing success payloads, and waits for an active database and discoverable shard.
3. Pins Redis database version `7.2` for the Redis Software 7.4 matrix entry. The correctly provisioned 7.4 report matches the existing reviewed baseline exactly, so no baseline weakening was needed.
4. Renders sanitized compliance summaries on both pass and fail paths and separately enforces the compliance and rendering outcomes after teardown.
5. Updates official GitHub actions to their current Node 24-backed majors: checkout/setup-python/upload-artifact v7 and download-artifact v8, verified from their upstream release tags and action manifests.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-features`
- `python3 -m unittest discover -s scripts/tests` (35 tests)
- `docker compose --profile init config --quiet`
- Fresh local Redis Software 7.4 bootstrap: first create receives the reproduced transient 406, retry succeeds, database/shard readiness succeeds, safe compliance matches the checked-in baseline
- Local Redis Software 8.0 safe compliance against the pinned image: passes with deterministic model fidelity
- Hosted five-version safe contract matrix: all jobs passed and cleaned up ([run 30944055939](https://github.com/redis-developer/redis-enterprise-rs/actions/runs/30944055939))
- Hosted Rust CI, dependency policy, measured coverage, Linux/macOS/Windows builds, Python unit tests, wheels, and smoke installs: all passed

Ready for merge.
